### PR TITLE
fix(clipboard): replace off-screen feedback with centered toast notif…

### DIFF
--- a/app/assets/tailwind/components/editor.css
+++ b/app/assets/tailwind/components/editor.css
@@ -72,25 +72,62 @@
     opacity: 1;
   }
 
-  /* Copied feedback toast */
-  .path-container.copied::after {
-    content: attr(data-copied-text);
-    position: absolute;
-    left: 50%;
-    top: -1.5rem;
-    transform: translateX(-50%);
-    background: var(--theme-accent);
-    color: white;
-    padding: 0.125rem 0.5rem;
-    border-radius: 0.25rem;
-    font-size: 0.75rem;
-    white-space: nowrap;
-    animation: fade-out 1.5s ease forwards;
+}
+
+/*
+ * Global toast notification
+ * Fixed position, bottom-center, responsive with proper text wrapping
+ */
+.app-toast {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%) translateY(0.5rem);
+  max-width: min(90vw, 420px);
+  padding: 0.75rem 1rem;
+  background: var(--theme-accent);
+  background: color-mix(in srgb, var(--theme-accent) 92%, transparent);
+  color: white;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  z-index: 9999;
+  /* Text wrapping for long translations */
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  /* Animation states */
+  opacity: 0;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  pointer-events: none;
+}
+
+.app-toast--visible {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+.app-toast--hiding {
+  opacity: 0;
+  transform: translateX(-50%) translateY(0.5rem);
+}
+
+/* Ensure toast is visible on smaller screens */
+@media (max-width: 480px) {
+  .app-toast {
+    left: 1rem;
+    right: 1rem;
+    max-width: none;
+    bottom: 0.5rem;
+    transform: translateY(0.5rem);
   }
 
-  @keyframes fade-out {
-    0% { opacity: 1; }
-    70% { opacity: 1; }
-    100% { opacity: 0; }
+  .app-toast--visible {
+    transform: translateY(0);
+  }
+
+  .app-toast--hiding {
+    transform: translateY(0.5rem);
   }
 }

--- a/app/javascript/controllers/path_display_controller.js
+++ b/app/javascript/controllers/path_display_controller.js
@@ -83,15 +83,43 @@ export default class extends Controller {
     if (!fullPath) return
 
     navigator.clipboard.writeText(fullPath).then(() => {
-      // Show copied feedback
-      this.element.dataset.copiedText = window.t("status.copied")
-      this.element.classList.add("copied")
-      setTimeout(() => {
-        this.element.classList.remove("copied")
-      }, 1500)
+      // Show toast feedback
+      this.showToast(window.t("status.copied_to_clipboard"))
     }).catch(err => {
       console.error("Failed to copy path:", err)
     })
+  }
+
+  // Show a toast notification that auto-dismisses
+  showToast(message, duration = 2000) {
+    // Remove any existing toast
+    const existingToast = document.getElementById("app-toast")
+    if (existingToast) {
+      existingToast.remove()
+    }
+
+    // Create toast element
+    const toast = document.createElement("div")
+    toast.id = "app-toast"
+    toast.className = "app-toast"
+    toast.setAttribute("role", "status")
+    toast.setAttribute("aria-live", "polite")
+    toast.textContent = message
+
+    document.body.appendChild(toast)
+
+    // Trigger animation after append
+    requestAnimationFrame(() => {
+      toast.classList.add("app-toast--visible")
+    })
+
+    // Auto-dismiss
+    setTimeout(() => {
+      toast.classList.remove("app-toast--visible")
+      toast.classList.add("app-toast--hiding")
+      // Remove from DOM after fade out animation
+      setTimeout(() => toast.remove(), 300)
+    }, duration)
   }
 
   // Show full path on hover (when truncated)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,6 +99,7 @@ en:
 
   # Status messages
   status:
+    copied_to_clipboard: "Content copied to clipboard"
     saved: "Saved"
     unsaved: "Unsaved changes"
     error_saving: "Error saving"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -99,6 +99,7 @@ es:
 
   # Status messages
   status:
+    copied_to_clipboard: "Contenido copiado al portapapeles"
     saved: "Guardado"
     unsaved: "Cambios sin guardar"
     error_saving: "Error al guardar"

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -96,6 +96,7 @@ he:
 
   # הודעות סטטוס
   status:
+    copied_to_clipboard: "התוכן הועתק ללוח"
     saved: "נשמר"
     unsaved: "שינויים לא שמורים"
     error_saving: "שגיאה בשמירה"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -99,6 +99,7 @@ ja:
 
   # Status messages
   status:
+    copied_to_clipboard: "クリップボードにコピーしました"
     saved: "保存済み"
     unsaved: "未保存の変更"
     error_saving: "保存エラー"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -99,6 +99,7 @@ ko:
 
   # 상태 메시지
   status:
+    copied_to_clipboard: "클립보드에 복사되었습니다"
     saved: "저장됨"
     unsaved: "저장되지 않은 변경사항"
     error_saving: "저장 오류"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -99,6 +99,7 @@ pt-BR:
 
   # Mensagens de status
   status:
+    copied_to_clipboard: "Conteúdo copiado para a área de transferência"
     saved: "Salvo"
     unsaved: "Alterações não salvas"
     error_saving: "Erro ao salvar"

--- a/config/locales/pt-PT.yml
+++ b/config/locales/pt-PT.yml
@@ -99,6 +99,7 @@ pt-PT:
 
   # Mensagens de estado
   status:
+    copied_to_clipboard: "Conteúdo copiado para a área de transferência"
     saved: "Guardado"
     unsaved: "Alterações por guardar"
     error_saving: "Erro ao guardar"

--- a/test/javascript/controllers/path_display_controller.test.js
+++ b/test/javascript/controllers/path_display_controller.test.js
@@ -94,18 +94,22 @@ describe("PathDisplayController", () => {
       expect(navigator.clipboard.writeText).not.toHaveBeenCalled()
     })
 
-    it("adds copied class temporarily", async () => {
+    it("shows toast notification temporarily", async () => {
       vi.useFakeTimers()
       controller.textTarget.dataset.fullPath = "test.md"
 
       controller.copy()
 
+      // Wait for clipboard promise to resolve
       await vi.waitFor(() => {
-        expect(element.classList.contains("copied")).toBe(true)
+        const toast = document.getElementById("app-toast")
+        expect(toast).toBeTruthy()
+        expect(toast.textContent).toBe("status.copied_to_clipboard")
       })
 
-      vi.advanceTimersByTime(1500)
-      expect(element.classList.contains("copied")).toBe(false)
+      // Toast should be removed after duration + fade out time
+      vi.advanceTimersByTime(2300)
+      expect(document.getElementById("app-toast")).toBeFalsy()
 
       vi.useRealTimers()
     })


### PR DESCRIPTION
# Copy Feedback UX Fix Summary

## Goal
Replace the off-screen clipboard feedback with a proper toast notification that is always visible, supports long i18n strings, and follows accessibility best practices.

Fixes #9 

Fixes copy feedback appearing clipped/off-screen on different viewport sizes and zoom levels.

## Changes Implemented
- Updated `app/javascript/controllers/path_display_controller.js`:
  - Replaced CSS class-based feedback with a new `showToast()` method.
  - Toast is dynamically created and appended to `document.body`.
  - Added `role="status"` and `aria-live="polite"` for screen reader accessibility.
  - Auto-dismisses after 2 seconds with fade-out animation.
  - Changed translation key from `status.copied` to `status.copied_to_clipboard`.

- Updated `app/assets/tailwind/components/editor.css`:
  - Removed old `.copied::after` pseudo-element that could render off-screen.
  - Added new `.app-toast` component with:
    - Fixed positioning at bottom-center (never clipped).
    - `max-width: min(90vw, 420px)` for responsive sizing.
    - `white-space: normal; overflow-wrap: anywhere;` for long translations.
    - Soft transparency using `color-mix()` with solid fallback.
    - Fade-in/out animations.
    - Mobile-friendly media query for screens < 480px.

- Added `status.copied_to_clipboard` translation key to all 7 locale files:
  - `en.yml`: "Content copied to clipboard"
  - `es.yml`: "Contenido copiado al portapapeles"
  - `pt-BR.yml`: "Conteúdo copiado para a área de transferência"
  - `pt-PT.yml`: "Conteúdo copiado para a área de transferência"
  - `ja.yml`: "クリップボードにコピーしました"
  - `ko.yml`: "클립보드에 복사되었습니다"
  - `he.yml`: "התוכן הועתק ללוח"

- Updated `test/javascript/controllers/path_display_controller.test.js`:
  - Changed test to verify toast element creation instead of CSS class toggle.

## Acceptance Criteria Met
- After clicking copy, the user sees a clear, localized message.
- The message is fully visible (never clipped/off-screen) at all viewport widths and zoom levels.
- Long translations wrap gracefully and remain readable.
- The feedback disappears automatically after 2 seconds.

## Tests
- Syntax validation passed.
- Unit tests updated but not run (dependencies not installed in environment).

## Result
- Image 1:
<img width="1911" height="877" alt="image" src="https://github.com/user-attachments/assets/84e2c37e-9d03-49b0-b157-c94caeef9fc8" />

