### PR TITLE
fix: detect macOS .app browsers in fed/fed.fish (#86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ set -gx FRANKMD_ENV ~/.config/frankmd/env
 
 ### 4. Browser (Optional)
 
-FrankMD checks for browsers in this order: **Chromium** -> Firefox -> Brave -> Chrome -> Edge. The first one found is used.
+FrankMD checks for browsers in this order: **Chromium** -> Firefox -> Brave -> Chrome -> Edge. The first one found is used. On Linux it looks for PATH commands; on macOS it also checks the matching `.app` bundles under `/Applications/`.
 
 To override, set `FRANKMD_BROWSER` in your shell config:
 
@@ -227,6 +227,9 @@ export FRANKMD_BROWSER=brave           # or chromium, google-chrome, microsoft-e
 
 # fish - add to ~/.config/fish/config.fish
 set -gx FRANKMD_BROWSER brave
+
+# macOS - point at the binary inside the .app bundle if auto-detection misses it
+export FRANKMD_BROWSER="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 ```
 
 For Firefox, enable SSB mode first: `about:config` -> `browser.ssb.enabled` = `true`

--- a/config/fed/fed.fish
+++ b/config/fed/fed.fish
@@ -2,11 +2,21 @@
 # Source this file in your ~/.config/fish/config.fish:
 #   source ~/.config/frankmd/fed.fish
 
+function _fed_is_macos
+    test (uname) = Darwin
+end
+
 # Detect the best available browser.
-# Override with: set -gx FRANKMD_BROWSER brave
+# Override with: set -gx FRANKMD_BROWSER brave  (PATH command or full path)
 function _fed_find_browser
     if set -q FRANKMD_BROWSER; and test -n "$FRANKMD_BROWSER"
+        # Accept either a PATH command or an absolute path to an executable
+        # (the macOS .app workaround: full path to the binary inside the bundle).
         if command -q "$FRANKMD_BROWSER"
+            echo "$FRANKMD_BROWSER"
+            return 0
+        end
+        if test -x "$FRANKMD_BROWSER"
             echo "$FRANKMD_BROWSER"
             return 0
         end
@@ -26,6 +36,25 @@ function _fed_find_browser
             return 0
         end
     end
+
+    # macOS: GUI browsers ship as .app bundles, not PATH commands (issue #86).
+    # Match the order above; the binary inside the bundle accepts --app / --ssb
+    # the same way as the Linux executable.
+    if _fed_is_macos
+        set -l mac_candidates \
+            "/Applications/Chromium.app/Contents/MacOS/Chromium" \
+            "/Applications/Firefox.app/Contents/MacOS/firefox" \
+            "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser" \
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+            "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge"
+        for path in $mac_candidates
+            if test -x "$path"
+                echo "$path"
+                return 0
+            end
+        end
+    end
+
     return 1
 end
 
@@ -122,14 +151,18 @@ function fed
     set -l browser (_fed_find_browser)
     if test -z "$browser"
         echo "[fed] Error: no supported browser found." >&2
-        echo "[fed] Install chromium, firefox, brave, google-chrome, or microsoft-edge," >&2
-        echo "[fed] or set FRANKMD_BROWSER to your browser command." >&2
+        echo "[fed] Linux: install chromium, firefox, brave, google-chrome, or microsoft-edge." >&2
+        echo "[fed] macOS: install one of those .app bundles under /Applications/." >&2
+        echo "[fed] Or set FRANKMD_BROWSER to a command on PATH or a full executable path." >&2
         return 1
     end
 
-    # Open browser with splash (polls until Rails is ready)
+    # Open browser with splash (polls until Rails is ready).
+    # Key off the basename so macOS bundle paths like
+    # /Applications/Firefox.app/Contents/MacOS/firefox still match `firefox*`.
     set -l url "file://$splash"
-    switch "$browser"
+    set -l browser_name (basename "$browser")
+    switch "$browser_name"
         case 'firefox*'
             "$browser" --ssb="$url" >/dev/null 2>&1 &
             disown >/dev/null 2>&1

--- a/config/fed/fed.sh
+++ b/config/fed/fed.sh
@@ -2,11 +2,21 @@
 # Source this file in your ~/.bashrc or ~/.zshrc:
 #   source ~/.config/frankmd/fed.sh
 
+_fed_is_macos() {
+  [[ "$(uname)" == "Darwin" ]]
+}
+
 # Detect the best available browser.
-# Override with: export FRANKMD_BROWSER=brave
+# Override with: export FRANKMD_BROWSER=brave  (PATH command or full path)
 _fed_find_browser() {
   if [[ -n "${FRANKMD_BROWSER:-}" ]]; then
+    # Accept either a PATH command or an absolute path to an executable
+    # (the macOS .app workaround: FRANKMD_BROWSER="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome").
     if command -v "$FRANKMD_BROWSER" >/dev/null 2>&1; then
+      echo "$FRANKMD_BROWSER"
+      return
+    fi
+    if [[ -x "$FRANKMD_BROWSER" ]]; then
       echo "$FRANKMD_BROWSER"
       return
     fi
@@ -26,6 +36,26 @@ _fed_find_browser() {
       return
     fi
   done
+
+  # macOS: GUI browsers ship as .app bundles, not PATH commands (issue #86).
+  # Match the order above; the binary inside the bundle accepts --app / --ssb
+  # the same way as the Linux executable.
+  if _fed_is_macos; then
+    local mac_candidates=(
+      "/Applications/Chromium.app/Contents/MacOS/Chromium"
+      "/Applications/Firefox.app/Contents/MacOS/firefox"
+      "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"
+      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+      "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge"
+    )
+    for path in "${mac_candidates[@]}"; do
+      if [[ -x "$path" ]]; then
+        echo "$path"
+        return
+      fi
+    done
+  fi
+
   return 1
 }
 
@@ -106,14 +136,18 @@ fed() {
   browser=$(_fed_find_browser)
   if [[ -z "$browser" ]]; then
     echo "[fed] Error: no supported browser found." >&2
-    echo "[fed] Install chromium, firefox, brave, google-chrome, or microsoft-edge," >&2
-    echo "[fed] or set FRANKMD_BROWSER to your browser command." >&2
+    echo "[fed] Linux: install chromium, firefox, brave, google-chrome, or microsoft-edge." >&2
+    echo "[fed] macOS: install one of those .app bundles under /Applications/." >&2
+    echo "[fed] Or set FRANKMD_BROWSER to a command on PATH or a full executable path." >&2
     return 1
   fi
 
   # Open browser with splash (polls until Rails is ready)
+  # Key off the basename so macOS bundle paths like
+  # /Applications/Firefox.app/Contents/MacOS/firefox still match `firefox*`.
   local url="file://$splash"
-  case "$browser" in
+  local browser_name="${browser##*/}"
+  case "$browser_name" in
     firefox*) "$browser" --ssb="$url" >/dev/null 2>&1 & disown ;;
     *)        "$browser" --app="$url" >/dev/null 2>&1 & disown ;;
   esac


### PR DESCRIPTION
## Summary

Closes #86.

On macOS, browsers ship as `.app` bundles under `/Applications/` rather than as PATH commands, so `_fed_find_browser` always missed and `fed` exited with *"no supported browser found"* even when Chrome was installed and set as the system default.

- After the PATH probe, also look up the same browsers (Chromium → Firefox → Brave → Chrome → Edge) at their standard bundle paths under `/Applications/<Name>.app/Contents/MacOS/` on macOS only. The binary inside each bundle accepts the same `--app=` / `--ssb=` flags as the Linux executable, so the launch path is unchanged once the basename is used for the firefox-vs-chrome routing.
- `FRANKMD_BROWSER` now also accepts a full executable path (the workaround the reporter used keeps working), and that form is documented in the README.
- Same change ported to `fed.fish`.

Behavior on Linux is unchanged.

## Test plan

- [x] `bash -n config/fed/fed.sh` clean
- [x] `fish -n config/fed/fed.fish` clean (run in a fish container since fish isn't installed locally)
- [x] Sourced both files; `_fed_is_macos`, `_fed_find_browser`, `fed`, `fed-update`, `fed-stop` all defined
- [x] Behavioral spot-checks (in a Linux container) for: (a) `FRANKMD_BROWSER` set to a full executable path is accepted, (b) basename of `/Applications/Firefox.app/Contents/MacOS/firefox` matches `firefox*`, (c) basename of `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome` does not match `firefox*`, (d) `_fed_is_macos` correctly returns false on Linux
- [x] Full project CI green (Ruby + JS) — unchanged by this PR but verified as a sanity check
- [ ] **macOS verification needed**: @matheus-rodrigues00 — when you have a moment, would you mind grabbing this branch's `config/fed/fed.sh` (or `fed.fish`), dropping it into `~/.config/frankmd/`, re-sourcing, and trying `fed ~/some-notes-dir` again? It should auto-detect Chrome without needing `FRANKMD_BROWSER` set. If it doesn't, the error message now also tells you to set `FRANKMD_BROWSER` to a full executable path, which is the workaround you already know works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)