### PR TITLE
ci: publish multi-arch (amd64/arm64) Docker images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,55 @@
+# Publishes the FrankMD image to Docker Hub as a multi-arch manifest
+# (linux/amd64 + linux/arm64), so it also runs on ARM hosts such as
+# Raspberry Pi / Orange Pi / Ampere VPS.
+#
+# Requirements (repository -> Settings -> Secrets and variables -> Actions):
+#   - DOCKERHUB_USERNAME : Docker Hub account/namespace (e.g. akitaonrails)
+#   - DOCKERHUB_TOKEN    : Docker Hub access token with write permission
+#
+# Triggers on version tags (e.g. v1.2.3) and on manual dispatch.
+name: Publish Docker image
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract image metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: akitaonrails/frankmd
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest
+
+      - name: Build and push (amd64 + arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## What

Adds `.github/workflows/docker-publish.yml` — builds and pushes a multi-arch image manifest (`linux/amd64` + `linux/arm64`) to Docker Hub via `docker buildx`, on version tags (`v*`) and manual dispatch.

## Why

`akitaonrails/frankmd:latest` is currently amd64-only, so it fails on ARM hosts (Raspberry Pi / Orange Pi / Ampere VPS) with:

    exec /rails/bin/docker-entrypoint: exec format error

The Dockerfile already uses a multi-arch base (`ruby:<version>-slim`) and `Gemfile.lock` already lists `aarch64-linux` / `arm-linux-*`, so only the publish step was single-arch.

Validated on a native aarch64 host: `docker build` succeeds and the container boots (Rails 8.1.3 / Puma 8 / Ruby 3.4.1 `[aarch64-linux]`), `/up` returns 200. See #90.

## Enabling it

Requires two repository secrets (Settings -> Secrets and variables -> Actions):

- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN` (write-scoped access token)

It pushes the git tag (e.g. `v1.2.3`) plus `latest`, and uses the GitHub Actions cache to speed up the emulated arm64 build.

## Contribution notes

- **Focused scope:** CI-only change, no application code touched.
- **Tests:** none added — there is nothing unit-testable in a publish workflow, and `bin/ci` (rubocop / brakeman / bundler-audit / importmap audit / Ruby + JS tests) is unaffected since no Ruby/JS/config it checks was changed.
- **Rebased** on the latest `master`, single commit, no merge commits.

Closes #90
