### PR TITLE
fix: open Firefox with --new-window so the window isn't blank (#86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ set -gx FRANKMD_BROWSER brave
 export FRANKMD_BROWSER="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 ```
 
-For Firefox, enable SSB mode first: `about:config` -> `browser.ssb.enabled` = `true`
+Firefox opens in a regular browser window (it has no Chromium-style app-window mode); use a Chromium-based browser for the borderless app experience.
 
 ### Running in Background
 

--- a/config/fed/fed.fish
+++ b/config/fed/fed.fish
@@ -38,7 +38,7 @@ function _fed_find_browser
     end
 
     # macOS: GUI browsers ship as .app bundles, not PATH commands (issue #86).
-    # Match the order above; the binary inside the bundle accepts --app / --ssb
+    # Match the order above; the binary inside the bundle accepts --app / --new-window
     # the same way as the Linux executable.
     if _fed_is_macos
         set -l mac_candidates \
@@ -164,7 +164,7 @@ function fed
     set -l browser_name (basename "$browser")
     switch "$browser_name"
         case 'firefox*'
-            "$browser" --ssb="$url" >/dev/null 2>&1 &
+            "$browser" --new-window "$url" >/dev/null 2>&1 &
             disown >/dev/null 2>&1
         case '*'
             "$browser" --app="$url" >/dev/null 2>&1 &

--- a/config/fed/fed.sh
+++ b/config/fed/fed.sh
@@ -38,7 +38,7 @@ _fed_find_browser() {
   done
 
   # macOS: GUI browsers ship as .app bundles, not PATH commands (issue #86).
-  # Match the order above; the binary inside the bundle accepts --app / --ssb
+  # Match the order above; the binary inside the bundle accepts --app / --new-window
   # the same way as the Linux executable.
   if _fed_is_macos; then
     local mac_candidates=(
@@ -148,7 +148,7 @@ fed() {
   local url="file://$splash"
   local browser_name="${browser##*/}"
   case "$browser_name" in
-    firefox*) "$browser" --ssb="$url" >/dev/null 2>&1 & disown ;;
+    firefox*) "$browser" --new-window "$url" >/dev/null 2>&1 & disown ;;
     *)        "$browser" --app="$url" >/dev/null 2>&1 & disown ;;
   esac
 }


### PR DESCRIPTION
## What

On macOS, `fed` now launches Firefox with `--new-window <url>` instead of the long-dead
`--ssb=<url>` flag, so the FrankMD splash/app actually shows up.

## Why

PR #89 fixed macOS browser detection by probing `/Applications/*.app` bundles — great, but it
also means Firefox (second in the priority list) now gets auto-selected on Macs that have it.
`fed` then opened it with `--ssb=`, Firefox's old "site-specific browser" flag, which was removed
from Firefox years ago. Since the URL was glued onto that unknown flag (`--ssb=file://…`), Firefox
never received a real URL and just opened a **blank window**. This is the part of #86 that was
still broken after #89.

## The fix

- `config/fed/fed.sh` / `config/fed/fed.fish`: Firefox launch flag `--ssb=` → `--new-window`
  (URL passed as its own argument). Also refreshed the stale `--app / --ssb` comment.
- `README.md`: replaced the outdated "enable `browser.ssb.enabled`" note — Firefox opens in a
  normal window (it has no Chromium-style app-window mode); use a Chromium-based browser for the
  borderless experience.

Firefox stays a supported, auto-detected browser; detection order, the `FRANKMD_BROWSER` override,
and Chromium/Brave/Chrome/Edge behavior are all untouched.

> **Heads-up:** Firefox has no equivalent to Chromium's `--app=`, so it opens as a regular window
> (tabs + URL bar), not the chromeless app window. That's a Firefox limitation, not a regression.

## Testing

Verified on a macOS machine that reproduces #86 (Firefox.app + Chrome.app installed, no PATH
commands):

- The real `fed.sh` dispatch now emits `--new-window <url>` for Firefox and still `--app=<url>`
  for Chrome.
- The installed Firefox's `--help` confirms `-new-window` exists and `ssb` no longer does.
- Launched Firefox live with `firefox --new-window file://…/splash.html` — the page renders
  instead of a blank window.

Closes #86.
