### PR TITLE
ci: strip "v" prefix from published Docker image tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           images: akitaonrails/frankmd
           tags: |
-            type=ref,event=tag
+            type=semver,pattern={{version}}
             type=raw,value=latest
 
       - name: Build and push (amd64 + arm64)


### PR DESCRIPTION
## What

Switch the `docker/metadata-action` tag strategy from `type=ref,event=tag` to `type=semver,pattern={{version}}`, so the published image tag drops its leading `v`: `akitaonrails/frankmd:0.3.1` instead of `:v0.3.1`.

## Why

`type=ref,event=tag` uses the raw git tag name as the image tag, so the pull command reads:

    docker pull akitaonrails/frankmd:v0.3.1

The `v` is redundant on the registry side (the tag already lives under the image name) and reads a bit awkwardly. `type=semver,pattern={{version}}` parses the git tag as semver and renders just the version:

    docker pull akitaonrails/frankmd:0.3.1

## Notes

- The git tag convention is unchanged: the workflow still triggers on `v*` tags. Only the rendered image tag is normalized.
- Pre-release tags keep working: `v1.0.0-beta.1` -> `1.0.0-beta.1`.
- `:latest` is still published on every tagged release.
- The already-published `:v0.3.1` image stays on Docker Hub; this only affects future releases.

## Contribution notes

- **Focused scope:** CI-only change, one line in `.github/workflows/docker-publish.yml`. No application code touched.
- **Tests:** none added - there is nothing unit-testable in a publish workflow, and `bin/ci` (rubocop / brakeman / bundler-audit / importmap audit / Ruby + JS tests) is unaffected since no Ruby/JS/config it checks was changed.
- **Rebased** on the latest `master`, single commit, no merge commits.

Follow-up to #91.