### PR TITLE
feat: show the app version in the About dialog and sidebar

### DIFF
--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -1,0 +1,28 @@
+# Asserts that lib/frankmd/version.rb (FrankMD::VERSION) matches the pushed
+# git tag, so the version constant and the release tag can never drift.
+name: Version guard
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+
+      - name: Verify FrankMD::VERSION matches the git tag
+        run: |
+          file_version="$(ruby -r ./lib/frankmd/version -e 'print FrankMD::VERSION')"
+          tag_version="${GITHUB_REF_NAME#v}"
+          if [ "$file_version" != "$tag_version" ]; then
+            echo "::error::FrankMD::VERSION ($file_version) does not match git tag $GITHUB_REF_NAME"
+            exit 1
+          fi
+          echo "Version OK: FrankMD::VERSION=$file_version matches tag $GITHUB_REF_NAME"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def app_version
+    FrankMD::VERSION
+  end
 end

--- a/app/views/notes/_sidebar.html.erb
+++ b/app/views/notes/_sidebar.html.erb
@@ -87,4 +87,9 @@
       </div>
     </div>
   </div>
+
+  <!-- Version -->
+  <div class="flex-none border-t border-[var(--theme-border)] px-3 py-1.5 text-xs text-[var(--theme-text-faint)] text-center">
+    <%= t('app.name') %> v<%= app_version %>
+  </div>
 </aside>

--- a/app/views/notes/dialogs/_help.html.erb
+++ b/app/views/notes/dialogs/_help.html.erb
@@ -354,6 +354,11 @@
         <%= t('dialogs.about.description') %>
       </p>
 
+      <!-- Version -->
+      <p class="text-xs text-[var(--theme-text-faint)] text-center mb-4">
+        v<%= app_version %>
+      </p>
+
       <!-- Copyright -->
       <p class="text-xs text-[var(--theme-text-faint)] text-center mb-4">
         &copy; <%= Time.current.year %> Fabio Akita. <%= t('dialogs.about.copyright') %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,8 @@ require "action_view/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+require_relative "../lib/frankmd/version"
+
 module FrankMD
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
@@ -26,7 +28,9 @@ module FrankMD
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[assets tasks])
+    # frankmd is require'd explicitly above (version.rb defines the
+    # FrankMD::VERSION constant, not a class), so Zeitwerk must skip it.
+    config.autoload_lib(ignore: %w[assets tasks frankmd])
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/lib/frankmd/version.rb
+++ b/lib/frankmd/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module FrankMD
+  VERSION = "0.3.2"
+end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ApplicationHelperTest < ActionView::TestCase
+  include ApplicationHelper
+
+  test "app_version returns the FrankMD version constant" do
+    assert_equal FrankMD::VERSION, app_version
+  end
+end


### PR DESCRIPTION
## What

Surface the running FrankMD version in the UI (from #94):
- **About** dialog: a muted `v0.3.2` under the tagline.
- **Explorer** sidebar footer: a centered, muted `FrankMD v0.3.2`.

## Preview

**About dialog**

<img src="https://github.com/user-attachments/assets/c1ba53aa-94c7-46e5-9b8d-d4beccb5154d" width="300" alt="About dialog showing v0.3.2 under the tagline">

**Explorer sidebar footer**

<img src="https://github.com/user-attachments/assets/1f211abb-ae51-4bc0-a2f6-d89ddec085f5" width="210" alt="Sidebar footer showing FrankMD v0.3.2 centered">

## How

- `lib/frankmd/version.rb` defines `FrankMD::VERSION` as the single source of truth, required at boot from `config/application.rb`. Since it defines a constant (not a `Frankmd::Version` class), `frankmd` is added to `autoload_lib(ignore:)` so Zeitwerk does not try to autoload it (which would otherwise break eager load in production).
- Exposed to views via `ApplicationHelper#app_version`.
- Both labels use `text-xs text-[var(--theme-text-faint)]`.
- The drift guard you suggested lives in a dedicated `.github/workflows/version-guard.yml` that runs only on tag push and asserts `FrankMD::VERSION` matches the tag — it does not touch the existing `ci.yml` / `docker-publish.yml`.

## One judgment call (flagging for review)

**Sidebar wording.** Your shape note said render `v<%= app_version %>` for both. About is bare (`v0.3.2`), but the sidebar footer renders `FrankMD v0.3.2` (via the existing `app.name` key — no new i18n key) since the footer has no nearby app name. Easy to switch to bare if you would prefer.

## Notes

- `VERSION` stays at `0.3.2` (the current release) as requested; the bump becomes a one-line edit alongside the next `releases/vX.Y.Z.md`.

## Contribution notes

- **Focused scope:** version wiring + the two UI labels + the dedicated guard workflow.
- **Tests:** added `test/helpers/application_helper_test.rb` asserting `app_version` returns `FrankMD::VERSION`. Verified on an arm64 host: `bin/rubocop` clean; helper + `notes_controller` tests green with assets compiled; production Docker image boots and renders the version.
- **Rebased** on latest `master`, single commit, no merge commits.

Closes #94.
