### PR TITLE
feat: drag drop media tab

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -9,12 +9,15 @@ class ImagesController < ApplicationController
 
   # GET /images/config
   def status
+    cfg = Config.new
     render json: {
       enabled: ImagesService.enabled?,
       s3_enabled: ImagesService.s3_enabled?,
       web_search_enabled: true,    # Uses DuckDuckGo/Bing (no API needed)
       google_enabled: google_api_configured?,  # Requires API keys
-      pinterest_enabled: true      # Uses DuckDuckGo with site filter (no API needed)
+      pinterest_enabled: true,     # Uses DuckDuckGo with site filter (no API needed)
+      image_extensions: cfg.upload_extensions("image_upload_extensions"),
+      video_extensions: cfg.upload_extensions("video_upload_extensions")
     }
   end
 

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class MediaController < ApplicationController
+  skip_forgery_protection only: [ :upload ]
+
+  # POST /media/upload
+  # Upload a video file from browser drag-and-drop
+  def upload
+    file = params[:file]
+    upload_to_s3 = params[:upload_to_s3] == "true"
+
+    unless file.present?
+      return render json: { error: t("errors.no_file_upload") }, status: :unprocessable_entity
+    end
+
+    result = MediaService.save_upload(file, upload_to_s3: upload_to_s3)
+
+    if result[:url]
+      render json: { url: result[:url] }
+    else
+      render json: { error: result[:error] || t("errors.upload_failed") }, status: :unprocessable_entity
+    end
+  rescue StandardError => e
+    Rails.logger.error "Media upload error: #{e.class} - #{e.message}"
+    Rails.logger.error e.backtrace.first(10).join("\n")
+    render json: { error: "#{e.class}: #{e.message}" }, status: :unprocessable_entity
+  end
+end

--- a/app/javascript/controllers/image_picker_controller.js
+++ b/app/javascript/controllers/image_picker_controller.js
@@ -9,16 +9,16 @@ export default class extends Controller {
   static targets = [
     "dialog",
     // Tab buttons
-    "tabLocal", "tabFolder", "tabWeb", "tabGoogle", "tabPinterest", "tabAi",
+    "tabDrop", "tabLocal", "tabFolder", "tabWeb", "tabGoogle", "tabPinterest", "tabAi",
     // Tab panels (contain nested controllers)
-    "panelLocal", "panelFolder", "panelWeb", "panelGoogle", "panelPinterest", "panelAi",
+    "panelDrop", "panelLocal", "panelFolder", "panelWeb", "panelGoogle", "panelPinterest", "panelAi",
     // Common options
     "options", "selectedName", "alt", "link",
     "loading", "loadingText", "insertBtn"
   ]
 
   connect() {
-    this.currentTab = "local"
+    this.currentTab = "drop"
     this.selectedSource = null
     this.selectedImageData = null
 
@@ -42,11 +42,14 @@ export default class extends Controller {
   }
 
   configureSourceControllers() {
+    const dropCtrl = this.getSourceController("drop-images")
+    if (dropCtrl) dropCtrl.configure(this.config.s3_enabled, this.config.image_extensions)
+
     const localCtrl = this.getSourceController("local-images")
     if (localCtrl) localCtrl.configure(this.config.enabled, this.config.s3_enabled)
 
     const folderCtrl = this.getSourceController("folder-images")
-    if (folderCtrl) folderCtrl.configure(this.config.s3_enabled)
+    if (folderCtrl) folderCtrl.configure(this.config.s3_enabled, this.config.image_extensions)
 
     const webCtrl = this.getSourceController("web-images")
     if (webCtrl) webCtrl.configure(this.config.s3_enabled)
@@ -75,11 +78,11 @@ export default class extends Controller {
   // Dialog management
   async open() {
     this.resetAll()
-    this.switchTab({ currentTarget: { dataset: { tab: "local" } } })
+    this.switchTab({ currentTarget: { dataset: { tab: "drop" } } })
 
-    // Activate the local tab
-    const localCtrl = this.getSourceController("local-images")
-    if (localCtrl) await localCtrl.activate()
+    // Activate the drop tab (default)
+    const dropCtrl = this.getSourceController("drop-images")
+    if (dropCtrl) await dropCtrl.activate()
 
     this.dialogTarget.showModal()
   }
@@ -98,7 +101,7 @@ export default class extends Controller {
   resetAll() {
     this.selectedSource = null
     this.selectedImageData = null
-    this.currentTab = "local"
+    this.currentTab = "drop"
 
     // Reset common UI
     if (this.hasAltTarget) this.altTarget.value = ""
@@ -107,7 +110,7 @@ export default class extends Controller {
     if (this.hasInsertBtnTarget) this.insertBtnTarget.disabled = true
 
     // Reset each source controller
-    const sources = ["local-images", "folder-images", "web-images", "google-images", "pinterest-images", "ai-images"]
+    const sources = ["drop-images", "local-images", "folder-images", "web-images", "google-images", "pinterest-images", "ai-images"]
     sources.forEach(name => {
       const ctrl = this.getSourceController(name)
       if (ctrl) ctrl.reset()
@@ -127,7 +130,7 @@ export default class extends Controller {
     const activeClasses = "border-[var(--theme-accent)] text-[var(--theme-accent)]"
     const inactiveClasses = "border-transparent text-[var(--theme-text-muted)] hover:text-[var(--theme-text-secondary)]"
 
-    const tabs = ["Local", "Folder", "Web", "Google", "Pinterest", "Ai"]
+    const tabs = ["Drop", "Local", "Folder", "Web", "Google", "Pinterest", "Ai"]
     tabs.forEach(t => {
       const tabTarget = this[`hasTab${t}Target`] ? this[`tab${t}Target`] : null
       const panelTarget = this[`hasPanel${t}Target`] ? this[`panel${t}Target`] : null
@@ -142,6 +145,7 @@ export default class extends Controller {
 
     // Activate the selected tab's controller
     const controllerMap = {
+      drop: "drop-images",
       local: "local-images",
       folder: "folder-images",
       web: "web-images",
@@ -156,7 +160,7 @@ export default class extends Controller {
 
   // Get ordered list of tab names
   getTabOrder() {
-    return ["local", "folder", "web", "google", "pinterest", "ai"]
+    return ["drop", "local", "folder", "web", "google", "pinterest", "ai"]
   }
 
   // Handle arrow key navigation on tab buttons

--- a/app/javascript/controllers/image_sources/drop_images_controller.js
+++ b/app/javascript/controllers/image_sources/drop_images_controller.js
@@ -1,0 +1,131 @@
+import { Controller } from "@hotwired/stimulus"
+import { FolderImageSource, DEFAULT_IMAGE_EXTENSIONS } from "lib/image_sources/folder_images"
+
+// Drop Images Tab Controller
+// Accepts drag-and-dropped image files. Reuses FolderImageSource machinery
+// (preview grid, select, upload) since dropped files are the same File objects
+// the folder picker produces.
+
+export default class extends Controller {
+  static targets = ["dropzone", "container", "grid", "status", "feedback"]
+
+  static values = {
+    s3Enabled: Boolean
+  }
+
+  connect() {
+    this.source = new FolderImageSource()
+    this.allowedExtensions = DEFAULT_IMAGE_EXTENSIONS
+    this.selectedImage = null
+  }
+
+  disconnect() {
+    this.source.cleanup()
+  }
+
+  get s3Option() {
+    const el = this.element.querySelector('[data-controller="s3-option"]')
+    return el ? this.application.getControllerForElementAndIdentifier(el, "s3-option") : null
+  }
+
+  // Called by parent controller when tab becomes active
+  activate() {}
+
+  configure(s3Enabled, imageExtensions = null) {
+    this.s3EnabledValue = s3Enabled
+    if (imageExtensions && imageExtensions.length) this.allowedExtensions = imageExtensions
+  }
+
+  onDragover(event) {
+    event.preventDefault()
+    this.dropzoneTarget.classList.add("border-[var(--theme-accent)]", "bg-[var(--theme-bg-tertiary)]")
+  }
+
+  onDragleave(event) {
+    event.preventDefault()
+    this.dropzoneTarget.classList.remove("border-[var(--theme-accent)]", "bg-[var(--theme-bg-tertiary)]")
+  }
+
+  async onDrop(event) {
+    event.preventDefault()
+    this.dropzoneTarget.classList.remove("border-[var(--theme-accent)]", "bg-[var(--theme-bg-tertiary)]")
+
+    const { count, rejected } = await this.source.ingest(event.dataTransfer.files, this.allowedExtensions)
+
+    this.showRejected(rejected)
+
+    if (count > 0) {
+      this.containerTarget.classList.remove("hidden")
+      this.source.renderGrid(
+        this.gridTarget,
+        this.hasStatusTarget ? this.statusTarget : null,
+        "click->drop-images#select",
+        count
+      )
+    } else {
+      this.containerTarget.classList.add("hidden")
+    }
+  }
+
+  showRejected(rejected) {
+    if (!this.hasFeedbackTarget) return
+
+    if (!rejected || rejected.length === 0) {
+      this.feedbackTarget.textContent = ""
+      this.feedbackTarget.classList.add("hidden")
+      return
+    }
+
+    const list = this.allowedExtensions.join(", ")
+    const messages = rejected.map(r =>
+      window.t("dialogs.image_picker.drop_rejected", { name: r.name, ext: r.ext, list })
+    )
+    this.feedbackTarget.textContent = messages.join(" ")
+    this.feedbackTarget.classList.remove("hidden")
+  }
+
+  select(event) {
+    const index = parseInt(event.currentTarget.dataset.index)
+    const image = this.source.getImage(index)
+    if (!image) return
+
+    this.selectedImage = { name: image.name, file: image.file }
+
+    this.source.deselectAll(this.gridTarget)
+    event.currentTarget.classList.add("selected")
+
+    if (this.s3EnabledValue && this.s3Option) {
+      this.s3Option.show()
+    }
+
+    this.dispatch("selected", {
+      detail: {
+        type: "drop",
+        name: image.name,
+        alt: image.name.replace(/\.[^.]+$/, "").replace(/[-_]/g, " ")
+      }
+    })
+  }
+
+  async getImageUrl() {
+    if (!this.selectedImage) return null
+
+    const s3 = this.s3Option
+    const uploadToS3 = this.s3EnabledValue && s3?.isChecked
+    const resizeRatio = s3?.resizeRatio || ""
+
+    const data = await this.source.upload(this.selectedImage.file, resizeRatio, uploadToS3)
+    return data.url
+  }
+
+  reset() {
+    this.source.reset()
+    this.selectedImage = null
+    if (this.hasFeedbackTarget) {
+      this.feedbackTarget.textContent = ""
+      this.feedbackTarget.classList.add("hidden")
+    }
+    if (this.hasContainerTarget) this.containerTarget.classList.add("hidden")
+    this.s3Option?.hide()
+  }
+}

--- a/app/javascript/controllers/image_sources/drop_images_controller.js
+++ b/app/javascript/controllers/image_sources/drop_images_controller.js
@@ -7,7 +7,7 @@ import { FolderImageSource, DEFAULT_IMAGE_EXTENSIONS } from "lib/image_sources/f
 // the folder picker produces.
 
 export default class extends Controller {
-  static targets = ["dropzone", "container", "grid", "status", "feedback"]
+  static targets = ["dropzone", "fileInput", "container", "grid", "status", "feedback"]
 
   static values = {
     s3Enabled: Boolean
@@ -49,8 +49,21 @@ export default class extends Controller {
   async onDrop(event) {
     event.preventDefault()
     this.dropzoneTarget.classList.remove("border-[var(--theme-accent)]", "bg-[var(--theme-bg-tertiary)]")
+    await this.ingestFiles(event.dataTransfer.files)
+  }
 
-    const { count, rejected } = await this.source.ingest(event.dataTransfer.files, this.allowedExtensions)
+  // Clicking the dropzone opens the native file picker
+  openPicker() {
+    if (this.hasFileInputTarget) this.fileInputTarget.click()
+  }
+
+  async onFileInputChange(event) {
+    await this.ingestFiles(event.target.files)
+    event.target.value = ""  // allow re-selecting the same file
+  }
+
+  async ingestFiles(fileList) {
+    const { count, rejected } = await this.source.ingest(fileList, this.allowedExtensions)
 
     this.showRejected(rejected)
 

--- a/app/javascript/controllers/image_sources/folder_images_controller.js
+++ b/app/javascript/controllers/image_sources/folder_images_controller.js
@@ -32,8 +32,9 @@ export default class extends Controller {
     this.setupUI()
   }
 
-  configure(s3Enabled) {
+  configure(s3Enabled, imageExtensions = null) {
     this.s3EnabledValue = s3Enabled
+    if (imageExtensions) this.allowedExtensions = imageExtensions
   }
 
   setupUI() {
@@ -52,7 +53,7 @@ export default class extends Controller {
   }
 
   async browse() {
-    const result = await this.source.browse()
+    const result = await this.source.browse(this.allowedExtensions)
     if (!result.error && !result.cancelled) {
       this.setupUI()
       this.source.renderGrid(

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -10,6 +10,7 @@ application.register("locale", LocaleController)
 // (subdirectory controllers would otherwise be registered as "image-sources--local-images")
 import LocalImagesController from "controllers/image_sources/local_images_controller"
 import FolderImagesController from "controllers/image_sources/folder_images_controller"
+import DropImagesController from "controllers/image_sources/drop_images_controller"
 import WebImagesController from "controllers/image_sources/web_images_controller"
 import GoogleImagesController from "controllers/image_sources/google_images_controller"
 import PinterestImagesController from "controllers/image_sources/pinterest_images_controller"
@@ -17,6 +18,7 @@ import AiImagesController from "controllers/image_sources/ai_images_controller"
 
 application.register("local-images", LocalImagesController)
 application.register("folder-images", FolderImagesController)
+application.register("drop-images", DropImagesController)
 application.register("web-images", WebImagesController)
 application.register("google-images", GoogleImagesController)
 application.register("pinterest-images", PinterestImagesController)

--- a/app/javascript/controllers/video_dialog_controller.js
+++ b/app/javascript/controllers/video_dialog_controller.js
@@ -14,7 +14,7 @@ export default class extends Controller {
     "dialog",
     "tabDrop", "tabUrl", "tabSearch",
     "dropPanel", "urlPanel", "searchPanel",
-    "dropzone", "dropPreview", "dropFeedback", "dropInsertBtn",
+    "dropzone", "dropFileInput", "dropPreview", "dropFeedback", "dropInsertBtn",
     "videoUrl", "videoPreview", "insertVideoBtn",
     "youtubeSearchInput", "youtubeSearchBtn",
     "youtubeSearchStatus", "youtubeSearchResults",
@@ -228,8 +228,20 @@ export default class extends Controller {
   async onDrop(event) {
     event.preventDefault()
     this.dropzoneTarget.classList.remove("border-[var(--theme-accent)]", "bg-[var(--theme-bg-tertiary)]")
+    await this.uploadVideoFile(event.dataTransfer.files[0])
+  }
 
-    const file = event.dataTransfer.files[0]
+  // Clicking the dropzone opens the native file picker
+  openPicker() {
+    if (this.hasDropFileInputTarget) this.dropFileInputTarget.click()
+  }
+
+  async onFileInputChange(event) {
+    await this.uploadVideoFile(event.target.files[0])
+    event.target.value = ""  // allow re-selecting the same file
+  }
+
+  async uploadVideoFile(file) {
     if (!file) return
 
     const ext = file.name.toLowerCase().match(/\.[^.]+$/)?.[0] || "no extension"

--- a/app/javascript/controllers/video_dialog_controller.js
+++ b/app/javascript/controllers/video_dialog_controller.js
@@ -1,7 +1,9 @@
 import { Controller } from "@hotwired/stimulus"
-import { get } from "@rails/request.js"
+import { get, post } from "@rails/request.js"
 import { escapeHtml } from "lib/text_utils"
 import { extractYouTubeId } from "lib/url_utils"
+
+const DEFAULT_VIDEO_EXTENSIONS = [".mp4", ".webm", ".mkv", ".mov", ".avi", ".m4v", ".ogv"]
 
 // Video Dialog Controller
 // Handles video embedding from URLs and YouTube search
@@ -10,8 +12,9 @@ import { extractYouTubeId } from "lib/url_utils"
 export default class extends Controller {
   static targets = [
     "dialog",
-    "tabUrl", "tabSearch",
-    "urlPanel", "searchPanel",
+    "tabDrop", "tabUrl", "tabSearch",
+    "dropPanel", "urlPanel", "searchPanel",
+    "dropzone", "dropPreview", "dropFeedback", "dropInsertBtn",
     "videoUrl", "videoPreview", "insertVideoBtn",
     "youtubeSearchInput", "youtubeSearchBtn",
     "youtubeSearchStatus", "youtubeSearchResults",
@@ -25,9 +28,32 @@ export default class extends Controller {
     this.youtubeApiEnabled = false
     this.detectedVideoType = null
     this.detectedVideoData = null
-    this.currentTab = "url"
+    this.currentTab = "drop"
+    this.s3Enabled = false
+    this.videoExtensions = DEFAULT_VIDEO_EXTENSIONS
 
     this.checkYoutubeApiEnabled()
+    this.loadMediaConfig()
+  }
+
+  async loadMediaConfig() {
+    try {
+      const response = await get("/images/config", { responseKind: "json" })
+      if (response.ok) {
+        const data = await response.json
+        this.s3Enabled = data.s3_enabled
+        if (data.video_extensions && data.video_extensions.length) {
+          this.videoExtensions = data.video_extensions
+        }
+      }
+    } catch (error) {
+      this.s3Enabled = false
+    }
+  }
+
+  get dropS3Option() {
+    const el = this.hasDropPanelTarget ? this.dropPanelTarget.querySelector('[data-controller="s3-option"]') : null
+    return el ? this.application.getControllerForElementAndIdentifier(el, "s3-option") : null
   }
 
   get useHugoShortcode() {
@@ -67,6 +93,9 @@ export default class extends Controller {
   }
 
   open() {
+    // Reset drop tab
+    this.resetDropTab()
+
     // Reset URL tab
     this.videoUrlTarget.value = ""
     this.videoPreviewTarget.innerHTML = `<span class="text-[var(--theme-text-muted)]">${window.t("dialogs.video.preview_hint")}</span>`
@@ -94,11 +123,10 @@ export default class extends Controller {
       this.youtubeSearchFormTarget.classList.toggle("hidden", !youtubeConfigured)
     }
 
-    // Reset to URL tab
-    this.switchTab({ currentTarget: { dataset: { tab: "url" } } })
+    // Reset to Drop tab (default)
+    this.switchTab({ currentTarget: { dataset: { tab: "drop" } } })
 
     this.dialogTarget.showModal()
-    this.videoUrlTarget.focus()
   }
 
   close() {
@@ -114,18 +142,16 @@ export default class extends Controller {
   switchToTab(tab) {
     this.currentTab = tab
 
-    // Update tab buttons
-    const urlTabClasses = tab === "url"
-      ? "border-[var(--theme-accent)] text-[var(--theme-accent)]"
-      : "border-transparent text-[var(--theme-text-muted)] hover:text-[var(--theme-text-secondary)]"
-    const searchTabClasses = tab === "search"
-      ? "border-[var(--theme-accent)] text-[var(--theme-accent)]"
-      : "border-transparent text-[var(--theme-text-muted)] hover:text-[var(--theme-text-secondary)]"
+    const active = "border-[var(--theme-accent)] text-[var(--theme-accent)]"
+    const inactive = "border-transparent text-[var(--theme-text-muted)] hover:text-[var(--theme-text-secondary)]"
+    const base = "px-4 py-2 text-sm font-medium border-b-2 "
 
-    this.tabUrlTarget.className = `px-4 py-2 text-sm font-medium border-b-2 ${urlTabClasses}`
-    this.tabSearchTarget.className = `px-4 py-2 text-sm font-medium border-b-2 ${searchTabClasses}`
+    if (this.hasTabDropTarget) this.tabDropTarget.className = base + (tab === "drop" ? active : inactive)
+    this.tabUrlTarget.className = base + (tab === "url" ? active : inactive)
+    this.tabSearchTarget.className = base + (tab === "search" ? active : inactive)
 
     // Show/hide panels
+    if (this.hasDropPanelTarget) this.dropPanelTarget.classList.toggle("hidden", tab !== "drop")
     this.urlPanelTarget.classList.toggle("hidden", tab !== "url")
     this.searchPanelTarget.classList.toggle("hidden", tab !== "search")
 
@@ -139,7 +165,7 @@ export default class extends Controller {
 
   // Get ordered list of tab names
   getTabOrder() {
-    return ["url", "search"]
+    return ["drop", "url", "search"]
   }
 
   // Handle arrow key navigation on tab buttons
@@ -186,6 +212,95 @@ export default class extends Controller {
     }
 
     this.switchToTab(tabs[newIndex])
+  }
+
+  // Drag-and-drop upload
+  onDragover(event) {
+    event.preventDefault()
+    this.dropzoneTarget.classList.add("border-[var(--theme-accent)]", "bg-[var(--theme-bg-tertiary)]")
+  }
+
+  onDragleave(event) {
+    event.preventDefault()
+    this.dropzoneTarget.classList.remove("border-[var(--theme-accent)]", "bg-[var(--theme-bg-tertiary)]")
+  }
+
+  async onDrop(event) {
+    event.preventDefault()
+    this.dropzoneTarget.classList.remove("border-[var(--theme-accent)]", "bg-[var(--theme-bg-tertiary)]")
+
+    const file = event.dataTransfer.files[0]
+    if (!file) return
+
+    const ext = file.name.toLowerCase().match(/\.[^.]+$/)?.[0] || "no extension"
+    if (!this.videoExtensions.some(e => file.name.toLowerCase().endsWith(e))) {
+      this.showDropFeedback(window.t("dialogs.video.drop_rejected", {
+        name: file.name, ext, list: this.videoExtensions.join(", ")
+      }))
+      return
+    }
+
+    this.showDropFeedback("")
+    this.dropPreviewTarget.classList.remove("hidden")
+    this.dropPreviewTarget.innerHTML = `<span class="text-[var(--theme-text-muted)]">${window.t("status.uploading") || "Uploading..."}</span>`
+
+    try {
+      const s3 = this.dropS3Option
+      const formData = new FormData()
+      formData.append("file", file)
+      if (this.s3Enabled && s3?.isChecked) formData.append("upload_to_s3", "true")
+
+      const response = await post("/media/upload", { body: formData, responseKind: "json" })
+      const data = await response.json
+
+      if (!response.ok) {
+        this.showDropFeedback(data.error || window.t("status.search_failed_retry"))
+        this.dropPreviewTarget.classList.add("hidden")
+        return
+      }
+
+      this.detectedVideoType = "file"
+      this.detectedVideoData = { url: data.url }
+      this.dropPreviewTarget.innerHTML = `
+        <div class="flex items-center gap-3">
+          <svg class="w-8 h-8 text-[var(--theme-accent)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <div class="min-w-0">
+            <div class="font-medium text-[var(--theme-text-primary)]">${window.t("dialogs.video.tab_drop")}</div>
+            <div class="text-xs text-[var(--theme-text-muted)] truncate max-w-[350px]">${escapeHtml(file.name)}</div>
+          </div>
+        </div>
+      `
+      if (this.hasDropInsertBtnTarget) this.dropInsertBtnTarget.disabled = false
+    } catch (error) {
+      console.error("Video upload error:", error)
+      this.showDropFeedback(window.t("status.search_failed_retry"))
+      this.dropPreviewTarget.classList.add("hidden")
+    }
+  }
+
+  showDropFeedback(message) {
+    if (!this.hasDropFeedbackTarget) return
+    this.dropFeedbackTarget.textContent = message
+    this.dropFeedbackTarget.classList.toggle("hidden", !message)
+  }
+
+  resetDropTab() {
+    this.showDropFeedback("")
+    if (this.hasDropPreviewTarget) {
+      this.dropPreviewTarget.innerHTML = ""
+      this.dropPreviewTarget.classList.add("hidden")
+    }
+    if (this.hasDropInsertBtnTarget) this.dropInsertBtnTarget.disabled = true
+
+    // Video uploads at drop time, so the S3 choice must be visible before the drop.
+    const s3 = this.dropS3Option
+    if (s3) {
+      s3.reset()
+      if (this.s3Enabled) s3.show(); else s3.hide()
+    }
   }
 
   onVideoUrlInput() {

--- a/app/javascript/lib/image_sources/folder_images.js
+++ b/app/javascript/lib/image_sources/folder_images.js
@@ -4,6 +4,15 @@
 import { post } from "@rails/request.js"
 import { escapeHtml } from "lib/text_utils"
 
+// Fallback when no config-driven list is provided (e.g. direct API use).
+export const DEFAULT_IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"]
+
+// Trailing extension of a filename (".png"), or a readable label when absent.
+export function extOf(filename) {
+  const match = filename.toLowerCase().match(/\.[^.]+$/)
+  return match ? match[0] : "no extension"
+}
+
 export class FolderImageSource {
   constructor() {
     this.displayedImages = []  // Images currently shown (with object URLs)
@@ -28,14 +37,14 @@ export class FolderImageSource {
     this.allImages = []
   }
 
-  async browse() {
+  async browse(allowedExtensions = DEFAULT_IMAGE_EXTENSIONS) {
     if (!this.isSupported) {
       return { error: "File System Access API not supported" }
     }
 
     try {
       const dirHandle = await window.showDirectoryPicker()
-      return await this.loadFromDirectory(dirHandle)
+      return await this.loadFromDirectory(dirHandle, allowedExtensions)
     } catch (err) {
       if (err.name === "AbortError") {
         return { cancelled: true }
@@ -45,10 +54,10 @@ export class FolderImageSource {
     }
   }
 
-  async loadFromDirectory(dirHandle) {
+  async loadFromDirectory(dirHandle, allowedExtensions = DEFAULT_IMAGE_EXTENSIONS) {
     this.cleanup()
 
-    const imageExtensions = [".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"]
+    const imageExtensions = allowedExtensions.map(ext => ext.toLowerCase())
 
     try {
       for await (const entry of dirHandle.values()) {
@@ -77,6 +86,34 @@ export class FolderImageSource {
       console.error("Error reading folder:", err)
       return { error: "Error reading folder" }
     }
+  }
+
+  // Ingest dropped File objects (drag-and-drop). Reuses all folder machinery.
+  // Returns { count, rejected: [{ name, reason }] } so the caller can tell the
+  // user why any file was skipped instead of silently dropping it.
+  async ingest(fileList, allowedExtensions = DEFAULT_IMAGE_EXTENSIONS) {
+    this.cleanup()
+
+    const allowed = allowedExtensions.map(ext => ext.toLowerCase())
+    const rejected = []
+
+    for (const file of fileList) {
+      if (allowed.some(ext => file.name.toLowerCase().endsWith(ext))) {
+        this.allImages.push({
+          name: file.name,
+          file: file,
+          lastModified: file.lastModified,
+          size: file.size
+        })
+      } else {
+        rejected.push({ name: file.name, ext: extOf(file.name) })
+      }
+    }
+
+    this.allImages.sort((a, b) => b.lastModified - a.lastModified)
+    await this.filter("")
+
+    return { count: this.allImages.length, rejected }
   }
 
   async filter(searchTerm) {

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -23,6 +23,10 @@ class Config
     # Paths (ENV defaults)
     "images_path" => { default: nil, type: :string, env: "IMAGES_PATH" },
 
+    # Accepted drag-and-drop upload extensions (comma-separated)
+    "image_upload_extensions" => { default: ".jpg,.jpeg,.png,.gif,.webp,.bmp", type: :string, env: "IMAGE_UPLOAD_EXTENSIONS" },
+    "video_upload_extensions" => { default: ".mp4,.webm,.mkv,.mov,.avi,.m4v,.ogv", type: :string, env: "VIDEO_UPLOAD_EXTENSIONS" },
+
     # AWS S3 Settings (ENV defaults)
     "aws_access_key_id" => { default: nil, type: :string, env: "AWS_ACCESS_KEY_ID" },
     "aws_secret_access_key" => { default: nil, type: :string, env: "AWS_SECRET_ACCESS_KEY" },
@@ -248,6 +252,12 @@ class Config
     else
       SCHEMA[key][:default]
     end
+  end
+
+  # Parse a comma-separated extension config key into a normalized array
+  # (e.g. ".JPG, .png " -> [".jpg", ".png"])
+  def upload_extensions(key)
+    get(key).to_s.split(",").map { |e| e.strip.downcase }.reject(&:blank?)
   end
 
   # Set a configuration value and save to file

--- a/app/services/media_service.rb
+++ b/app/services/media_service.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+# Handles drag-and-drop video uploads.
+# Saves to notes/videos/ (served via NotesController#serve_asset) or to S3.
+# Unlike images, videos are never resized/re-encoded.
+class MediaService
+  VIDEO_MIME_TYPES = {
+    ".mp4"  => "video/mp4",
+    ".webm" => "video/webm",
+    ".mkv"  => "video/x-matroska",
+    ".mov"  => "video/quicktime",
+    ".avi"  => "video/x-msvideo",
+    ".m4v"  => "video/x-m4v",
+    ".ogv"  => "video/ogg"
+  }.freeze
+
+  class << self
+    # Save an uploaded video file locally or to S3.
+    # Returns { url: "..." } on success or { error: "..." } on failure.
+    def save_upload(uploaded_file, upload_to_s3: false)
+      return { error: "No file provided" } unless uploaded_file
+
+      extension = File.extname(uploaded_file.original_filename.to_s).downcase
+      allowed = Config.new.upload_extensions("video_upload_extensions")
+      unless allowed.include?(extension)
+        shown = extension.presence || "no extension"
+        return { error: "#{shown} is not an accepted video type. Accepted: #{allowed.join(', ')}" }
+      end
+
+      require "securerandom"
+      require "fileutils"
+
+      temp_dir = Rails.root.join("tmp", "uploads")
+      FileUtils.mkdir_p(temp_dir)
+      temp_path = temp_dir.join("#{SecureRandom.hex(8)}_#{uploaded_file.original_filename}")
+      File.binwrite(temp_path, uploaded_file.read)
+
+      begin
+        if upload_to_s3 && ImagesService.s3_enabled?
+          upload_to_s3(temp_path, uploaded_file.original_filename)
+        else
+          save_to_notes_directory(temp_path, uploaded_file.original_filename)
+        end
+      ensure
+        FileUtils.rm_f(temp_path)
+      end
+    end
+
+    private
+
+    def save_to_notes_directory(temp_path, original_filename)
+      require "fileutils"
+
+      notes_path = Pathname.new(ENV.fetch("NOTES_PATH", Rails.root.join("notes")))
+      videos_dir = notes_path.join("videos")
+      FileUtils.mkdir_p(videos_dir)
+
+      timestamp = Time.now.strftime("%Y%m%d_%H%M%S")
+      safe_name = original_filename.gsub(/[^a-zA-Z0-9._-]/, "_")
+      dest_filename = "#{timestamp}_#{safe_name}"
+      FileUtils.cp(temp_path, videos_dir.join(dest_filename))
+
+      { url: "videos/#{dest_filename}" }
+    end
+
+    def upload_to_s3(temp_path, original_filename)
+      require "aws-sdk-s3"
+
+      cfg = Config.new
+      bucket = cfg.get("aws_s3_bucket")
+      region = cfg.get("aws_region") || "us-east-1"
+
+      client = Aws::S3::Client.new(
+        access_key_id: cfg.get("aws_access_key_id"),
+        secret_access_key: cfg.get("aws_secret_access_key"),
+        region: region
+      )
+
+      filename = original_filename.gsub(/[^a-zA-Z0-9._-]/, "_")
+      key = "frankmd/#{Time.current.strftime('%Y/%m')}/#{filename}"
+      content_type = VIDEO_MIME_TYPES[File.extname(filename).downcase] || "application/octet-stream"
+
+      begin
+        client.put_object(
+          bucket: bucket,
+          key: key,
+          body: File.binread(temp_path),
+          content_type: content_type
+        )
+      rescue Aws::S3::Errors::AccessControlListNotSupported
+        # Bucket has ACLs disabled, which is fine
+      end
+
+      encoded_key = key.split("/").map { |part| ERB::Util.url_encode(part) }.join("/")
+      { url: "https://#{bucket}.s3.#{region}.amazonaws.com/#{encoded_key}" }
+    end
+  end
+end

--- a/app/views/notes/dialogs/_image_picker.html.erb
+++ b/app/views/notes/dialogs/_image_picker.html.erb
@@ -17,9 +17,19 @@
         type="button"
         role="tab"
         data-action="click->image-picker#switchTab keydown->image-picker#onTabKeydown"
+        data-tab="drop"
+        data-image-picker-target="tabDrop"
+        class="px-4 py-2 text-sm font-medium border-b-2 border-[var(--theme-accent)] text-[var(--theme-accent)]"
+      >
+        <%= t('dialogs.image_picker.tab_drop') %>
+      </button>
+      <button
+        type="button"
+        role="tab"
+        data-action="click->image-picker#switchTab keydown->image-picker#onTabKeydown"
         data-tab="local"
         data-image-picker-target="tabLocal"
-        class="px-4 py-2 text-sm font-medium border-b-2 border-[var(--theme-accent)] text-[var(--theme-accent)]"
+        class="px-4 py-2 text-sm font-medium border-b-2 border-transparent text-[var(--theme-text-muted)] hover:text-[var(--theme-text-secondary)]"
       >
         <%= t('dialogs.image_picker.tab_local') %>
       </button>
@@ -78,9 +88,37 @@
     <!-- Scrollable Content Area -->
     <div class="flex-1 min-h-0 overflow-y-auto">
 
-    <!-- Tab Content: Local Images (server-side images_path) -->
+    <!-- Tab Content: Drop (drag-and-drop upload) -->
     <div
       class="p-4"
+      data-image-picker-target="panelDrop"
+      data-controller="drop-images"
+      data-action="drop-images:selected->image-picker#onSourceSelected"
+    >
+      <div
+        data-drop-images-target="dropzone"
+        data-action="dragover->drop-images#onDragover dragleave->drop-images#onDragleave drop->drop-images#onDrop"
+        class="border-2 border-dashed border-[var(--theme-border)] rounded-lg p-10 text-center text-sm text-[var(--theme-text-muted)] transition-colors"
+      >
+        <svg class="w-10 h-10 mx-auto mb-3 text-[var(--theme-text-muted)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+        </svg>
+        <%= t('dialogs.image_picker.drop_hint') %>
+      </div>
+
+      <div class="hidden mt-2 text-xs text-[var(--theme-warning)]" data-drop-images-target="feedback"></div>
+
+      <div class="hidden mt-3" data-drop-images-target="container">
+        <div class="grid grid-cols-5 gap-2 mb-2 max-h-[300px] overflow-y-auto" data-drop-images-target="grid"></div>
+        <div class="text-xs text-[var(--theme-text-muted)]" data-drop-images-target="status"></div>
+      </div>
+
+      <%= render "notes/dialogs/s3_option", mode: "upload" %>
+    </div>
+
+    <!-- Tab Content: Local Images (server-side images_path) -->
+    <div
+      class="p-4 hidden"
       data-image-picker-target="panelLocal"
       data-controller="local-images"
       data-action="local-images:selected->image-picker#onSourceSelected"

--- a/app/views/notes/dialogs/_image_picker.html.erb
+++ b/app/views/notes/dialogs/_image_picker.html.erb
@@ -97,14 +97,23 @@
     >
       <div
         data-drop-images-target="dropzone"
-        data-action="dragover->drop-images#onDragover dragleave->drop-images#onDragleave drop->drop-images#onDrop"
-        class="border-2 border-dashed border-[var(--theme-border)] rounded-lg p-10 text-center text-sm text-[var(--theme-text-muted)] transition-colors"
+        data-action="click->drop-images#openPicker dragover->drop-images#onDragover dragleave->drop-images#onDragleave drop->drop-images#onDrop"
+        class="border-2 border-dashed border-[var(--theme-border)] rounded-lg p-10 text-center text-sm text-[var(--theme-text-muted)] transition-colors cursor-pointer hover:border-[var(--theme-accent)]"
       >
         <svg class="w-10 h-10 mx-auto mb-3 text-[var(--theme-text-muted)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
         </svg>
         <%= t('dialogs.image_picker.drop_hint') %>
       </div>
+      <input
+        type="file"
+        accept="image/*"
+        multiple
+        class="hidden"
+        data-drop-images-target="fileInput"
+        data-action="change->drop-images#onFileInputChange"
+      >
+
 
       <div class="hidden mt-2 text-xs text-[var(--theme-warning)]" data-drop-images-target="feedback"></div>
 

--- a/app/views/notes/dialogs/_s3_option.html.erb
+++ b/app/views/notes/dialogs/_s3_option.html.erb
@@ -2,8 +2,10 @@
     Parameters:
     - mode: "upload" (default) or "reupload"
     - description: optional custom description text
+    - show_resize: show the resize dropdown (default true; false for videos)
 %>
 <% mode ||= "upload" %>
+<% show_resize = true if show_resize.nil? %>
 <%
   label = mode == "reupload" ? t('dialogs.s3_option.reupload_to_s3') : t('dialogs.s3_option.upload_to_s3')
   description ||= mode == "reupload" ?
@@ -24,6 +26,7 @@
   <p class="text-xs text-[var(--theme-text-muted)] mt-1 ml-6">
     <%= description %>
   </p>
+  <% if show_resize %>
   <!-- Resize option (only when S3 is checked) -->
   <div class="hidden mt-2 ml-6" data-s3-option-target="resizeOption">
     <label class="flex items-center gap-2 text-sm">
@@ -40,4 +43,5 @@
       <span class="text-[var(--theme-text-muted)]"><%= t('dialogs.s3_option.compress') %></span>
     </label>
   </div>
+  <% end %>
 </div>

--- a/app/views/notes/dialogs/_video.html.erb
+++ b/app/views/notes/dialogs/_video.html.erb
@@ -60,14 +60,22 @@
       <div class="p-4" data-video-dialog-target="dropPanel">
         <div
           data-video-dialog-target="dropzone"
-          data-action="dragover->video-dialog#onDragover dragleave->video-dialog#onDragleave drop->video-dialog#onDrop"
-          class="border-2 border-dashed border-[var(--theme-border)] rounded-lg p-10 text-center text-sm text-[var(--theme-text-muted)] transition-colors"
+          data-action="click->video-dialog#openPicker dragover->video-dialog#onDragover dragleave->video-dialog#onDragleave drop->video-dialog#onDrop"
+          class="border-2 border-dashed border-[var(--theme-border)] rounded-lg p-10 text-center text-sm text-[var(--theme-text-muted)] transition-colors cursor-pointer hover:border-[var(--theme-accent)]"
         >
           <svg class="w-10 h-10 mx-auto mb-3 text-[var(--theme-text-muted)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
           </svg>
           <%= t('dialogs.video.drop_hint') %>
         </div>
+        <input
+          type="file"
+          accept="video/*"
+          class="hidden"
+          data-video-dialog-target="dropFileInput"
+          data-action="change->video-dialog#onFileInputChange"
+        >
+
 
         <div class="hidden mt-2 text-xs text-[var(--theme-warning)]" data-video-dialog-target="dropFeedback"></div>
         <div class="hidden mt-4 p-3 bg-[var(--theme-bg-tertiary)] rounded-md text-sm" data-video-dialog-target="dropPreview"></div>

--- a/app/views/notes/dialogs/_video.html.erb
+++ b/app/views/notes/dialogs/_video.html.erb
@@ -28,9 +28,19 @@
           type="button"
           role="tab"
           data-action="click->video-dialog#switchTab keydown->video-dialog#onTabKeydown"
+          data-tab="drop"
+          data-video-dialog-target="tabDrop"
+          class="px-4 py-2 text-sm font-medium border-b-2 border-[var(--theme-accent)] text-[var(--theme-accent)]"
+        >
+          <%= t('dialogs.video.tab_drop') %>
+        </button>
+        <button
+          type="button"
+          role="tab"
+          data-action="click->video-dialog#switchTab keydown->video-dialog#onTabKeydown"
           data-tab="url"
           data-video-dialog-target="tabUrl"
-          class="px-4 py-2 text-sm font-medium border-b-2 border-[var(--theme-accent)] text-[var(--theme-accent)]"
+          class="px-4 py-2 text-sm font-medium border-b-2 border-transparent text-[var(--theme-text-muted)] hover:text-[var(--theme-text-secondary)]"
         >
           <%= t('dialogs.video.tab_url') %>
         </button>
@@ -46,8 +56,40 @@
         </button>
       </div>
 
+      <!-- Tab Content: Drop (drag-and-drop upload) -->
+      <div class="p-4" data-video-dialog-target="dropPanel">
+        <div
+          data-video-dialog-target="dropzone"
+          data-action="dragover->video-dialog#onDragover dragleave->video-dialog#onDragleave drop->video-dialog#onDrop"
+          class="border-2 border-dashed border-[var(--theme-border)] rounded-lg p-10 text-center text-sm text-[var(--theme-text-muted)] transition-colors"
+        >
+          <svg class="w-10 h-10 mx-auto mb-3 text-[var(--theme-text-muted)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+          </svg>
+          <%= t('dialogs.video.drop_hint') %>
+        </div>
+
+        <div class="hidden mt-2 text-xs text-[var(--theme-warning)]" data-video-dialog-target="dropFeedback"></div>
+        <div class="hidden mt-4 p-3 bg-[var(--theme-bg-tertiary)] rounded-md text-sm" data-video-dialog-target="dropPreview"></div>
+
+        <%= render "notes/dialogs/s3_option", mode: "upload", show_resize: false %>
+
+        <div class="flex justify-end gap-2 mt-4">
+          <%= render "shared/button_secondary", label: t('common.cancel'), action: "click->video-dialog#close" %>
+          <button
+            type="button"
+            data-action="click->video-dialog#insertVideo"
+            data-video-dialog-target="dropInsertBtn"
+            class="px-3 py-1.5 text-sm rounded-md bg-[var(--theme-accent)] text-[var(--theme-accent-text)] hover:bg-[var(--theme-accent-hover)] disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled
+          >
+            <%= t('dialogs.video.insert_video') %>
+          </button>
+        </div>
+      </div>
+
       <!-- Tab Content: URL -->
-      <div class="p-4" data-video-dialog-target="urlPanel">
+      <div class="p-4 hidden" data-video-dialog-target="urlPanel">
         <div class="mb-4">
           <label class="block text-xs text-[var(--theme-text-muted)] mb-1"><%= t('dialogs.video.url_label') %></label>
           <input

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -186,8 +186,12 @@ en:
     # Video dialog
     video:
       title: "Insert Video"
+      tab_drop: "Drop"
       tab_url: "URL / File"
       tab_search: "YouTube Search"
+      drop_hint: "Drag & drop a video file here"
+      drop_rejected: "%{name}: %{ext} is not an accepted video type. Accepted: %{list}"
+      uploading: "Uploading..."
       url_label: "Video URL or Path"
       url_placeholder: "YouTube URL or video file path..."
       url_hint_youtube: "YouTube: https://youtube.com/watch?v=... or https://youtu.be/..."
@@ -211,6 +215,7 @@ en:
     # Image picker dialog
     image_picker:
       title: "Insert Image"
+      tab_drop: "Drop"
       tab_local: "Local"
       tab_folder: "Folder"
       tab_web: "Web Search"
@@ -224,6 +229,9 @@ en:
       link_label: "Link URL (optional, makes image clickable)"
       link_placeholder: "https://..."
       uploading_to_s3: "Uploading to S3..."
+      # Drag-and-drop
+      drop_hint: "Drag & drop an image here"
+      drop_rejected: "%{name}: %{ext} is not an accepted image type. Accepted: %{list}"
       # Local images
       local_path_required: "Local Images Path Required"
       local_path_description: "To browse local images, configure an images directory path."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -180,6 +180,8 @@ es:
     # Video dialog
     video:
       title: "Insertar Video"
+      tab_drop: "Soltar"
+      drop_hint: "Arrastra y suelta un archivo de vídeo aquí"
       tab_url: "URL / Archivo"
       tab_search: "Buscar en YouTube"
       url_label: "URL o Ruta del Video"
@@ -205,6 +207,8 @@ es:
     # Image picker dialog
     image_picker:
       title: "Insertar Imagen"
+      tab_drop: "Soltar"
+      drop_hint: "Arrastra y suelta una imagen aquí"
       tab_local: "Local"
       tab_folder: "Carpeta"
       tab_web: "Búsqueda Web"

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -177,6 +177,8 @@ he:
     # דיאלוג סרטון
     video:
       title: "הוסף סרטון"
+      tab_drop: "גרירה"
+      drop_hint: "גררו ושחררו קובץ וידאו כאן"
       tab_url: "URL / קובץ"
       tab_search: "חיפוש YouTube"
       url_label: "URL או נתיב סרטון"
@@ -202,6 +204,8 @@ he:
     # דיאלוג בוחר תמונות
     image_picker:
       title: "הוסף תמונה"
+      tab_drop: "גרירה"
+      drop_hint: "גררו ושחררו תמונה כאן"
       tab_local: "מקומי"
       tab_folder: "תיקייה"
       tab_web: "חיפוש באינטרנט"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -180,6 +180,8 @@ ja:
     # Video dialog
     video:
       title: "動画を挿入"
+      tab_drop: "ドロップ"
+      drop_hint: "ここに動画ファイルをドラッグ＆ドロップ"
       tab_url: "URL / ファイル"
       tab_search: "YouTube検索"
       url_label: "動画URLまたはパス"
@@ -205,6 +207,8 @@ ja:
     # Image picker dialog
     image_picker:
       title: "画像を挿入"
+      tab_drop: "ドロップ"
+      drop_hint: "ここに画像をドラッグ＆ドロップ"
       tab_local: "ローカル"
       tab_folder: "フォルダ"
       tab_web: "Web検索"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -180,6 +180,8 @@ ko:
     # 동영상 다이얼로그
     video:
       title: "동영상 삽입"
+      tab_drop: "드롭"
+      drop_hint: "여기에 동영상 파일을 끌어다 놓으세요"
       tab_url: "URL / 파일"
       tab_search: "YouTube 검색"
       url_label: "동영상 URL 또는 경로"
@@ -205,6 +207,8 @@ ko:
     # 이미지 선택 다이얼로그
     image_picker:
       title: "이미지 삽입"
+      tab_drop: "드롭"
+      drop_hint: "여기에 이미지를 끌어다 놓으세요"
       tab_local: "로컬"
       tab_folder: "폴더"
       tab_web: "웹 검색"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -186,6 +186,8 @@ pt-BR:
     # Diálogo de vídeo
     video:
       title: "Inserir Vídeo"
+      tab_drop: "Soltar"
+      drop_hint: "Arraste e solte um arquivo de vídeo aqui"
       tab_url: "URL / Arquivo"
       tab_search: "Busca YouTube"
       url_label: "URL ou Caminho do Vídeo"
@@ -211,6 +213,8 @@ pt-BR:
     # Diálogo do seletor de imagens
     image_picker:
       title: "Inserir Imagem"
+      tab_drop: "Soltar"
+      drop_hint: "Arraste e solte uma imagem aqui"
       tab_local: "Local"
       tab_folder: "Pasta"
       tab_web: "Busca Web"

--- a/config/locales/pt-PT.yml
+++ b/config/locales/pt-PT.yml
@@ -180,6 +180,8 @@ pt-PT:
     # Diálogo de vídeo
     video:
       title: "Inserir Vídeo"
+      tab_drop: "Largar"
+      drop_hint: "Arraste e largue um ficheiro de vídeo aqui"
       tab_url: "URL / Ficheiro"
       tab_search: "Pesquisa YouTube"
       url_label: "URL ou Caminho do Vídeo"
@@ -205,6 +207,8 @@ pt-PT:
     # Diálogo do seletor de imagens
     image_picker:
       title: "Inserir Imagem"
+      tab_drop: "Largar"
+      drop_hint: "Arraste e largue uma imagem aqui"
       tab_local: "Local"
       tab_folder: "Pasta"
       tab_web: "Pesquisa Web"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,9 @@ Rails.application.routes.draw do
   get "images/search_google", to: "images#search_google"
   get "images/search_pinterest", to: "images#search_pinterest"
 
+  # Media API (video drag-and-drop uploads)
+  post "media/upload", to: "media#upload"
+
   # YouTube API
   get "youtube/config", to: "youtube#status"
   get "youtube/search", to: "youtube#search"

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -17,6 +17,15 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
     assert_includes [ true, false ], data["pinterest_enabled"]
   end
 
+  test "config exposes accepted upload extensions" do
+    get images_config_url, as: :json
+    assert_response :success
+
+    data = JSON.parse(response.body)
+    assert_includes data["image_extensions"], ".png"
+    assert_includes data["video_extensions"], ".mp4"
+  end
+
   # === Web Search ===
 
   test "search_web returns error when query is blank" do
@@ -82,6 +91,7 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
       @config_stub.stubs(:feature_available?).with(:local_images).returns(true)
       @config_stub.stubs(:feature_available?).with(:s3_upload).returns(false)
       @config_stub.stubs(:ui_settings).returns({})
+      @config_stub.stubs(:upload_extensions).returns([])
       Config.stubs(:new).returns(@config_stub)
     end
 
@@ -308,6 +318,7 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
       @config_stub.stubs(:feature_available?).with(:local_images).returns(true)
       @config_stub.stubs(:feature_available?).with(:s3_upload).returns(true)
       @config_stub.stubs(:ui_settings).returns({})
+      @config_stub.stubs(:upload_extensions).returns([])
       Config.stubs(:new).returns(@config_stub)
 
       @mock_s3_client = stub("s3_client")
@@ -406,6 +417,7 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
       @config_stub.stubs(:feature_available?).returns(false)
       @config_stub.stubs(:feature_available?).with(:local_images).returns(true)
       @config_stub.stubs(:ui_settings).returns({})
+      @config_stub.stubs(:upload_extensions).returns([])
       Config.stubs(:new).returns(@config_stub)
 
       WebMock.disable_net_connect!(allow_localhost: true)
@@ -577,6 +589,7 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
       @config_stub.stubs(:get).returns(nil)
       @config_stub.stubs(:feature_available?).returns(false)
       @config_stub.stubs(:ui_settings).returns({})
+      @config_stub.stubs(:upload_extensions).returns([])
       Config.stubs(:new).returns(@config_stub)
     end
 

--- a/test/controllers/media_controller_test.rb
+++ b/test/controllers/media_controller_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MediaControllerTest < ActionDispatch::IntegrationTest
+  def video_file(filename, content = "fake video bytes")
+    Rack::Test::UploadedFile.new(StringIO.new(content), "video/mp4", original_filename: filename)
+  end
+
+  test "upload returns error when no file provided" do
+    post "/media/upload"
+    assert_response :unprocessable_entity
+
+    data = JSON.parse(response.body)
+    assert_includes data["error"], "No file"
+  end
+
+  test "upload saves an allowed video to notes/videos" do
+    post "/media/upload", params: { file: video_file("clip.mp4") }
+    assert_response :success
+
+    data = JSON.parse(response.body)
+    assert data["url"].start_with?("videos/")
+    assert data["url"].include?("clip")
+
+    notes_path = Pathname.new(ENV.fetch("NOTES_PATH", Rails.root.join("notes")))
+    created = notes_path.join(data["url"])
+    FileUtils.rm_f(created) if created.exist?
+  end
+
+  test "upload rejects a disallowed extension with a reason" do
+    post "/media/upload", params: { file: video_file("notes.txt") }
+    assert_response :unprocessable_entity
+
+    data = JSON.parse(response.body)
+    assert_includes data["error"], "not an accepted video type"
+  end
+end

--- a/test/javascript/controllers/video_dialog_controller.test.js
+++ b/test/javascript/controllers/video_dialog_controller.test.js
@@ -20,6 +20,7 @@ describe("VideoDialogController", () => {
         <button data-video-dialog-target="tabSearch" data-tab="search"></button>
         <div data-video-dialog-target="dropPanel">
           <div data-video-dialog-target="dropzone"></div>
+          <input data-video-dialog-target="dropFileInput" type="file" />
           <div data-video-dialog-target="dropFeedback" class="hidden"></div>
           <div data-video-dialog-target="dropPreview" class="hidden"></div>
           <button data-video-dialog-target="dropInsertBtn" disabled></button>
@@ -547,6 +548,29 @@ describe("VideoDialogController", () => {
 
       expect(controller.detectedVideoType).toBeNull()
       expect(controller.dropFeedbackTarget.textContent).toBe("boom")
+    })
+  })
+
+  describe("openPicker() / onFileInputChange()", () => {
+    it("opens the native file picker when the dropzone is clicked", () => {
+      const clickSpy = vi.spyOn(controller.dropFileInputTarget, "click").mockImplementation(() => {})
+      controller.openPicker()
+      expect(clickSpy).toHaveBeenCalled()
+    })
+
+    it("uploads a file selected via the picker", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ url: "videos/picked.mp4" })
+      })
+
+      await controller.onFileInputChange({
+        target: { files: [ new File([ "d" ], "picked.mp4", { type: "video/mp4" }) ], value: "picked.mp4" }
+      })
+
+      expect(controller.detectedVideoType).toBe("file")
+      expect(controller.detectedVideoData.url).toBe("videos/picked.mp4")
+      expect(controller.dropInsertBtnTarget.disabled).toBe(false)
     })
   })
 

--- a/test/javascript/controllers/video_dialog_controller.test.js
+++ b/test/javascript/controllers/video_dialog_controller.test.js
@@ -15,8 +15,15 @@ describe("VideoDialogController", () => {
     document.body.innerHTML = `
       <div data-controller="video-dialog">
         <dialog data-video-dialog-target="dialog"></dialog>
+        <button data-video-dialog-target="tabDrop" data-tab="drop"></button>
         <button data-video-dialog-target="tabUrl" data-tab="url"></button>
         <button data-video-dialog-target="tabSearch" data-tab="search"></button>
+        <div data-video-dialog-target="dropPanel">
+          <div data-video-dialog-target="dropzone"></div>
+          <div data-video-dialog-target="dropFeedback" class="hidden"></div>
+          <div data-video-dialog-target="dropPreview" class="hidden"></div>
+          <button data-video-dialog-target="dropInsertBtn" disabled></button>
+        </div>
         <div data-video-dialog-target="urlPanel"></div>
         <div data-video-dialog-target="searchPanel" class="hidden"></div>
         <input data-video-dialog-target="videoUrl" type="text" />
@@ -493,6 +500,53 @@ describe("VideoDialogController", () => {
       controller.selectYoutubeVideo(event)
 
       expect(closeSpy).toHaveBeenCalled()
+    })
+  })
+
+  describe("onDrop() (drag-and-drop upload)", () => {
+    function dropEvent(fileName) {
+      return {
+        preventDefault: vi.fn(),
+        dataTransfer: { files: [ new File([ "data" ], fileName, { type: "video/mp4" }) ] }
+      }
+    }
+
+    it("rejects a disallowed extension with a reason and does not upload", async () => {
+      const fetchSpy = vi.fn()
+      global.fetch = fetchSpy
+
+      await controller.onDrop(dropEvent("notes.txt"))
+
+      expect(fetchSpy).not.toHaveBeenCalled()
+      expect(controller.detectedVideoType).toBeNull()
+      expect(controller.dropFeedbackTarget.classList.contains("hidden")).toBe(false)
+      expect(controller.dropFeedbackTarget.textContent).toBe("dialogs.video.drop_rejected")
+    })
+
+    it("uploads a valid video and enables the insert button", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ url: "videos/clip.mp4" })
+      })
+
+      await controller.onDrop(dropEvent("clip.mp4"))
+
+      expect(global.fetch).toHaveBeenCalledWith("/media/upload", expect.objectContaining({ method: "POST" }))
+      expect(controller.detectedVideoType).toBe("file")
+      expect(controller.detectedVideoData.url).toBe("videos/clip.mp4")
+      expect(controller.dropInsertBtnTarget.disabled).toBe(false)
+    })
+
+    it("surfaces the server error when upload fails", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        json: () => Promise.resolve({ error: "boom" })
+      })
+
+      await controller.onDrop(dropEvent("clip.mp4"))
+
+      expect(controller.detectedVideoType).toBeNull()
+      expect(controller.dropFeedbackTarget.textContent).toBe("boom")
     })
   })
 

--- a/test/javascript/image_sources/drop_images.test.js
+++ b/test/javascript/image_sources/drop_images.test.js
@@ -1,0 +1,78 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { FolderImageSource, extOf, DEFAULT_IMAGE_EXTENSIONS } from "../../../app/javascript/lib/image_sources/folder_images.js"
+
+// The Drop tab reuses FolderImageSource.ingest() to turn dropped File objects
+// into the same preview/upload machinery the Folder tab uses.
+describe("FolderImageSource.ingest (drag-and-drop)", () => {
+  let source
+
+  beforeEach(() => {
+    source = new FolderImageSource()
+
+    global.URL.createObjectURL = vi.fn().mockReturnValue("blob:http://localhost/mock-url")
+    global.URL.revokeObjectURL = vi.fn()
+
+    global.Image = class {
+      constructor() {
+        setTimeout(() => {
+          this.naturalWidth = 100
+          this.naturalHeight = 100
+          if (this.onload) this.onload()
+        }, 0)
+      }
+    }
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function file(name) {
+    return { name, lastModified: 1, size: 10 }
+  }
+
+  it("accepts files whose extension is in the allowed list", async () => {
+    const result = await source.ingest([file("a.png"), file("b.jpg")], DEFAULT_IMAGE_EXTENSIONS)
+
+    expect(result.count).toBe(2)
+    expect(result.rejected).toEqual([])
+  })
+
+  it("rejects disallowed files and reports the extension as the reason", async () => {
+    const result = await source.ingest([file("a.png"), file("notes.txt")], DEFAULT_IMAGE_EXTENSIONS)
+
+    expect(result.count).toBe(1)
+    expect(result.rejected).toHaveLength(1)
+    expect(result.rejected[0].name).toBe("notes.txt")
+    expect(result.rejected[0].ext).toBe(".txt")
+  })
+
+  it("labels files with no extension", async () => {
+    const result = await source.ingest([file("README")], DEFAULT_IMAGE_EXTENSIONS)
+
+    expect(result.count).toBe(0)
+    expect(result.rejected[0].ext).toBe("no extension")
+  })
+
+  it("respects a custom (config-overridden) extension list", async () => {
+    // Only .webp allowed -> a png is now rejected.
+    const result = await source.ingest([file("a.png"), file("b.webp")], [".webp"])
+
+    expect(result.count).toBe(1)
+    expect(result.rejected).toHaveLength(1)
+    expect(result.rejected[0].name).toBe("a.png")
+  })
+})
+
+describe("extOf", () => {
+  it("returns the trailing extension", () => {
+    expect(extOf("video.final.MP4")).toBe(".mp4")
+  })
+
+  it("returns a readable label when there is no extension", () => {
+    expect(extOf("README")).toBe("no extension")
+  })
+})

--- a/test/models/config_test.rb
+++ b/test/models/config_test.rb
@@ -110,6 +110,33 @@ class ConfigTest < ActiveSupport::TestCase
     assert_nil config.get(:theme)
   end
 
+  # === Upload extensions ===
+
+  test "upload_extensions returns the default image list" do
+    config = Config.new(base_path: @test_dir)
+
+    exts = config.upload_extensions("image_upload_extensions")
+    assert_includes exts, ".png"
+    assert_includes exts, ".jpg"
+  end
+
+  test "upload_extensions returns the default video list" do
+    config = Config.new(base_path: @test_dir)
+
+    exts = config.upload_extensions("video_upload_extensions")
+    assert_includes exts, ".mp4"
+    assert_includes exts, ".webm"
+  end
+
+  test "upload_extensions normalizes whitespace and case" do
+    ENV["VIDEO_UPLOAD_EXTENSIONS"] = " .MP4 , .MOV "
+    config = Config.new(base_path: @test_dir)
+
+    assert_equal [ ".mp4", ".mov" ], config.upload_extensions("video_upload_extensions")
+  ensure
+    ENV.delete("VIDEO_UPLOAD_EXTENSIONS")
+  end
+
   # === Reading from File ===
 
   test "reads values from config file" do

--- a/test/services/media_service_test.rb
+++ b/test/services/media_service_test.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MediaServiceTest < ActiveSupport::TestCase
+  DEFAULT_VIDEO_EXTENSIONS = %w[.mp4 .webm .mkv .mov .avi .m4v .ogv].freeze
+
+  def setup
+    @config_stub = stub("config")
+    @config_stub.stubs(:get).returns(nil)
+    @config_stub.stubs(:upload_extensions).with("video_upload_extensions").returns(DEFAULT_VIDEO_EXTENSIONS)
+    Config.stubs(:new).returns(@config_stub)
+
+    @notes_path = Pathname.new(ENV.fetch("NOTES_PATH", Rails.root.join("notes")))
+  end
+
+  def uploaded(filename, content = "fake video bytes")
+    Rack::Test::UploadedFile.new(StringIO.new(content), "video/mp4", original_filename: filename)
+  end
+
+  test "save_upload returns error when no file provided" do
+    result = MediaService.save_upload(nil)
+    assert result[:error]
+  end
+
+  test "save_upload writes an allowed video to notes/videos" do
+    result = MediaService.save_upload(uploaded("clip.mp4"))
+
+    assert result[:url], "expected a url, got #{result.inspect}"
+    assert result[:url].start_with?("videos/")
+    assert result[:url].include?("clip")
+
+    saved = @notes_path.join(result[:url])
+    assert saved.exist?
+    FileUtils.rm_f(saved)
+  end
+
+  test "save_upload rejects a disallowed extension with a reason" do
+    result = MediaService.save_upload(uploaded("notes.txt"))
+
+    assert_nil result[:url]
+    assert_includes result[:error], ".txt"
+    assert_includes result[:error], "not an accepted video type"
+  end
+
+  test "save_upload rejects a file with no extension" do
+    result = MediaService.save_upload(uploaded("README"))
+
+    assert_nil result[:url]
+    assert_includes result[:error], "no extension"
+  end
+
+  test "save_upload sanitizes the stored filename" do
+    result = MediaService.save_upload(uploaded("my cool clip!.mp4"))
+
+    assert result[:url]
+    refute_includes result[:url], " "
+    refute_includes result[:url], "!"
+
+    FileUtils.rm_f(@notes_path.join(result[:url]))
+  end
+end
+
+# S3 branch (with mocks)
+class MediaServiceS3Test < ActiveSupport::TestCase
+  require "aws-sdk-s3"
+
+  DEFAULT_VIDEO_EXTENSIONS = %w[.mp4 .webm .mkv .mov .avi .m4v .ogv].freeze
+
+  def setup
+    @config_stub = stub("config")
+    @config_stub.stubs(:get).returns(nil)
+    @config_stub.stubs(:get).with("aws_access_key_id").returns("test-key")
+    @config_stub.stubs(:get).with("aws_secret_access_key").returns("test-secret")
+    @config_stub.stubs(:get).with("aws_s3_bucket").returns("test-bucket")
+    @config_stub.stubs(:get).with("aws_region").returns("us-east-1")
+    @config_stub.stubs(:upload_extensions).with("video_upload_extensions").returns(DEFAULT_VIDEO_EXTENSIONS)
+    Config.stubs(:new).returns(@config_stub)
+
+    WebMock.disable_net_connect!(allow_localhost: true)
+  end
+
+  def teardown
+    WebMock.reset!
+    WebMock.allow_net_connect!
+  end
+
+  def uploaded(filename, content = "fake video bytes")
+    Rack::Test::UploadedFile.new(StringIO.new(content), "video/mp4", original_filename: filename)
+  end
+
+  test "save_upload uploads to S3 with the correct video mime type" do
+    mock_client = stub
+    mock_client.expects(:put_object).with { |args| args[:content_type] == "video/webm" }.returns(nil)
+    Aws::S3::Client.stubs(:new).returns(mock_client)
+
+    result = MediaService.save_upload(uploaded("movie.webm"), upload_to_s3: true)
+
+    assert result[:url]
+    assert_match %r{^https://test-bucket\.s3\.us-east-1\.amazonaws\.com/frankmd/\d{4}/\d{2}/movie\.webm$}, result[:url]
+  end
+
+  test "save_upload falls back to local storage when S3 not configured" do
+    @config_stub.stubs(:get).with("aws_access_key_id").returns(nil)
+
+    result = MediaService.save_upload(uploaded("local.mp4"), upload_to_s3: true)
+
+    assert result[:url].start_with?("videos/")
+    FileUtils.rm_f(Pathname.new(ENV.fetch("NOTES_PATH", Rails.root.join("notes"))).join(result[:url]))
+  end
+end


### PR DESCRIPTION
## What

Adds a **Drop** tab (now the default tab) to both the image picker and the
video dialog. Users can **drag & drop** a file onto the zone — or **click** the
zone to open the native file picker — to insert an image or video without
leaving the editor.

- **Image picker → Drop:** drop/pick image(s), preview thumbnails, insert as
  `![alt](images/…)`. Honors the existing S3 upload option.
- **Video dialog → Drop:** drop/pick a video, upload, insert as
  `<video src="videos/…">`. Optional S3 upload too.

Also adding new config keys for configuring media files that are accepted on both image and video handlings.
## Preview

<img width="1401" height="752" alt="image" src="https://github.com/user-attachments/assets/4bdad380-d4dd-43de-bcc1-be9874770e0a" />

<img width="1420" height="755" alt="image" src="https://github.com/user-attachments/assets/47d6cae5-aaa0-4f8d-96d9-8fa8cf0d4dbd" />

## Why

Every existing source (Local, Folder, Web, YouTube, …) makes you navigate or
search. The most common case — "I have this file right here" — had no path.
Drag-and-drop (with click-to-pick as the fallback for people who don't drag) is
the shortest route from a local file to an inserted asset.

What really made me implement this is actually running FrankMD on my homeserver and accessing it using Tailscale. So the files are on my device, not on the running FrankMD server, and drag-and-drop makes it faster then selecting a folder on the "Folder" tab. 