### PR TITLE
feat: paste image upload

### DIFF
--- a/app/javascript/controllers/app_controller.js
+++ b/app/javascript/controllers/app_controller.js
@@ -668,6 +668,13 @@ export default class extends Controller {
     if (this.hasImagePickerOutlet) this.imagePickerOutlet.open()
   }
 
+  // Image pasted into the editor: open the picker with it pre-selected, so the
+  // user finishes through the normal Insert flow (alt/link/S3 all still apply).
+  onImagePaste(event) {
+    const { file } = event.detail
+    if (file && this.hasImagePickerOutlet) this.imagePickerOutlet.openWithFile(file)
+  }
+
   // === Editor Customization - Delegates to customize_controller ===
   openCustomize() {
     if (this.hasCustomizeOutlet) {

--- a/app/javascript/controllers/app_controller.js
+++ b/app/javascript/controllers/app_controller.js
@@ -668,8 +668,7 @@ export default class extends Controller {
     if (this.hasImagePickerOutlet) this.imagePickerOutlet.open()
   }
 
-  // Image pasted into the editor: open the picker with it pre-selected, so the
-  // user finishes through the normal Insert flow (alt/link/S3 all still apply).
+  // Route pasted images through the picker (pre-selected) so the normal Insert flow still applies
   onImagePaste(event) {
     const { file } = event.detail
     if (file && this.hasImagePickerOutlet) this.imagePickerOutlet.openWithFile(file)

--- a/app/javascript/controllers/codemirror_controller.js
+++ b/app/javascript/controllers/codemirror_controller.js
@@ -59,7 +59,8 @@ export default class extends Controller {
       lineNumberMode: this.lineNumberModeValue,
       onUpdate: (update) => this.onDocumentChange(update),
       onSelectionChange: (update) => this.onSelectionChange(update),
-      onScroll: (event, view) => this.onScroll(event, view)
+      onScroll: (event, view) => this.onScroll(event, view),
+      onPaste: (file) => this.onImagePaste(file)
     })
 
     // Add typewriter extension
@@ -167,6 +168,10 @@ export default class extends Controller {
         scrollRatio: this.getScrollRatio()
       }
     })
+  }
+
+  onImagePaste(file) {
+    this.dispatch("image-pasted", { detail: { file } })
   }
 
   // === Public API (textarea-compatible) ===

--- a/app/javascript/controllers/image_picker_controller.js
+++ b/app/javascript/controllers/image_picker_controller.js
@@ -87,6 +87,17 @@ export default class extends Controller {
     this.dialogTarget.showModal()
   }
 
+  // Open the picker with an externally-provided File (e.g. a pasted image),
+  // routed through the Drop source and pre-selected so Insert is ready.
+  async openWithFile(file) {
+    await this.open()
+    const dropCtrl = this.getSourceController("drop-images")
+    if (!dropCtrl) return
+    this.showLoading(window.t("dialogs.image_picker.processing"))
+    await dropCtrl.loadExternalFile(file)
+    this.hideLoading()
+  }
+
   close() {
     const folderCtrl = this.getSourceController("folder-images")
     if (folderCtrl) folderCtrl.source.cleanup()
@@ -254,7 +265,7 @@ export default class extends Controller {
     if (!ctrl) return
 
     try {
-      this.showLoading("Processing image...")
+      this.showLoading(window.t("dialogs.image_picker.processing"))
       this.insertBtnTarget.disabled = true
 
       const imageUrl = await ctrl.getImageUrl()

--- a/app/javascript/controllers/image_picker_controller.js
+++ b/app/javascript/controllers/image_picker_controller.js
@@ -93,7 +93,7 @@ export default class extends Controller {
     await this.open()
     const dropCtrl = this.getSourceController("drop-images")
     if (!dropCtrl) return
-    this.showLoading(window.t("dialogs.image_picker.processing"))
+    this.showLoading(window.t("dialogs.image_picker.processing_image_paste"))
     await dropCtrl.loadExternalFile(file)
     this.hideLoading()
   }
@@ -265,7 +265,7 @@ export default class extends Controller {
     if (!ctrl) return
 
     try {
-      this.showLoading(window.t("dialogs.image_picker.processing"))
+      this.showLoading("Processing image...")
       this.insertBtnTarget.disabled = true
 
       const imageUrl = await ctrl.getImageUrl()

--- a/app/javascript/controllers/image_picker_controller.js
+++ b/app/javascript/controllers/image_picker_controller.js
@@ -87,8 +87,6 @@ export default class extends Controller {
     this.dialogTarget.showModal()
   }
 
-  // Open the picker with an externally-provided File (e.g. a pasted image),
-  // routed through the Drop source and pre-selected so Insert is ready.
   async openWithFile(file) {
     await this.open()
     const dropCtrl = this.getSourceController("drop-images")

--- a/app/javascript/controllers/image_sources/drop_images_controller.js
+++ b/app/javascript/controllers/image_sources/drop_images_controller.js
@@ -142,9 +142,7 @@ export default class extends Controller {
     })
   }
 
-  // Load a File that arrived from outside a drop event (e.g. a clipboard paste),
-  // then auto-select it so the picker opens ready to Insert. A rejected file
-  // renders no grid item; ingestFiles has already shown the reason.
+  // A rejected file renders no grid item; ingestFiles has already shown the reason.
   async loadExternalFile(file) {
     await this.ingestFiles([file])
     const el = this.gridTarget.querySelector('[data-index="0"]')

--- a/app/javascript/controllers/image_sources/drop_images_controller.js
+++ b/app/javascript/controllers/image_sources/drop_images_controller.js
@@ -117,14 +117,17 @@ export default class extends Controller {
   }
 
   select(event) {
-    const index = parseInt(event.currentTarget.dataset.index)
+    this.selectByIndex(parseInt(event.currentTarget.dataset.index), event.currentTarget)
+  }
+
+  selectByIndex(index, el) {
     const image = this.source.getImage(index)
     if (!image) return
 
     this.selectedImage = { name: image.name, file: image.file }
 
     this.source.deselectAll(this.gridTarget)
-    event.currentTarget.classList.add("selected")
+    if (el) el.classList.add("selected")
 
     if (this.s3EnabledValue && this.s3Option) {
       this.s3Option.show()
@@ -137,6 +140,15 @@ export default class extends Controller {
         alt: image.name.replace(/\.[^.]+$/, "").replace(/[-_]/g, " ")
       }
     })
+  }
+
+  // Load a File that arrived from outside a drop event (e.g. a clipboard paste),
+  // then auto-select it so the picker opens ready to Insert. A rejected file
+  // renders no grid item; ingestFiles has already shown the reason.
+  async loadExternalFile(file) {
+    await this.ingestFiles([file])
+    const el = this.gridTarget.querySelector('[data-index="0"]')
+    if (el) this.selectByIndex(0, el)
   }
 
   async getImageUrl() {

--- a/app/javascript/lib/clipboard_image.js
+++ b/app/javascript/lib/clipboard_image.js
@@ -1,0 +1,30 @@
+// Helpers for extracting a pasted image out of a clipboard event so it can be
+// fed into the image-picker Drop source (same File machinery as drag-and-drop).
+
+const EXT_BY_MIME = {
+  "image/png": ".png",
+  "image/jpeg": ".jpg",
+  "image/gif": ".gif",
+  "image/webp": ".webp",
+  "image/bmp": ".bmp"
+}
+
+// Return an image File from clipboard data, or null if there is no image.
+export function imageFileFromClipboard(clipboardData) {
+  if (!clipboardData) return null
+  for (const item of clipboardData.items || []) {
+    if (item.kind === "file" && item.type.startsWith("image/")) {
+      const file = item.getAsFile()
+      if (file) return normalizeImageFile(file)
+    }
+  }
+  return null
+}
+
+// Clipboard images often arrive with an empty or extension-less name; the Drop
+// ingest validates by filename extension, so synthesize one from the MIME type.
+export function normalizeImageFile(file) {
+  if (/\.[a-z0-9]+$/i.test(file.name || "")) return file
+  const ext = EXT_BY_MIME[file.type] || ".png"
+  return new File([file], `pasted-image-${file.lastModified || "clip"}${ext}`, { type: file.type })
+}

--- a/app/javascript/lib/clipboard_image.js
+++ b/app/javascript/lib/clipboard_image.js
@@ -1,5 +1,4 @@
-// Helpers for extracting a pasted image out of a clipboard event so it can be
-// fed into the image-picker Drop source (same File machinery as drag-and-drop).
+// Extract a pasted image from a clipboard event as a File the image-picker Drop source can ingest.
 
 const EXT_BY_MIME = {
   "image/png": ".png",
@@ -9,7 +8,6 @@ const EXT_BY_MIME = {
   "image/bmp": ".bmp"
 }
 
-// Return an image File from clipboard data, or null if there is no image.
 export function imageFileFromClipboard(clipboardData) {
   if (!clipboardData) return null
   for (const item of clipboardData.items || []) {

--- a/app/javascript/lib/codemirror_extensions.js
+++ b/app/javascript/lib/codemirror_extensions.js
@@ -251,8 +251,7 @@ export function createExtensions(options = {}) {
     }))
   }
 
-  // Paste listener - intercept only when the clipboard carries an image, so a
-  // plain-text paste falls through to CodeMirror's default handling untouched.
+  // Intercept only when the clipboard carries an image; plain-text paste falls through to CodeMirror's default
   if (onPaste) {
     extensions.push(EditorView.domEventHandlers({
       paste(event) {

--- a/app/javascript/lib/codemirror_extensions.js
+++ b/app/javascript/lib/codemirror_extensions.js
@@ -10,6 +10,7 @@ import { searchKeymap, highlightSelectionMatches } from "@codemirror/search"
 import { createTheme } from "lib/codemirror_theme"
 import { LINE_NUMBER_MODES } from "lib/line_numbers"
 import { createWikilinkAutocomplete } from "lib/codemirror_wikilink"
+import { imageFileFromClipboard } from "lib/clipboard_image"
 
 // Re-export for convenience
 export { LINE_NUMBER_MODES }
@@ -158,6 +159,7 @@ const markdownKeymap = Prec.highest(keymap.of([
  * @param {Function} options.onUpdate - Callback for document updates
  * @param {Function} options.onSelectionChange - Callback for selection changes
  * @param {Function} options.onScroll - Callback for scroll events
+ * @param {Function} options.onPaste - Callback(file) when an image is pasted
  * @returns {Extension[]} - Array of CodeMirror extensions
  */
 export function createExtensions(options = {}) {
@@ -169,7 +171,8 @@ export function createExtensions(options = {}) {
     lineNumberMode = LINE_NUMBER_MODES.OFF,
     onUpdate = null,
     onSelectionChange = null,
-    onScroll = null
+    onScroll = null,
+    onPaste = null
   } = options
 
   const extensions = [
@@ -244,6 +247,19 @@ export function createExtensions(options = {}) {
       }
       destroy() {
         this.view.scrollDOM.removeEventListener("scroll", this.onScroll)
+      }
+    }))
+  }
+
+  // Paste listener - intercept only when the clipboard carries an image, so a
+  // plain-text paste falls through to CodeMirror's default handling untouched.
+  if (onPaste) {
+    extensions.push(EditorView.domEventHandlers({
+      paste(event) {
+        const file = imageFileFromClipboard(event.clipboardData)
+        if (!file) return false
+        onPaste(file)
+        return true
       }
     }))
   }

--- a/app/views/notes/_editor_panel.html.erb
+++ b/app/views/notes/_editor_panel.html.erb
@@ -130,7 +130,7 @@
     </div>
     <div class="h-full hidden relative" data-app-target="editor"
          data-controller="codemirror typewriter"
-         data-action="codemirror:change->app#onEditorChange codemirror:selection-change->app#onEditorSelectionChange codemirror:scroll->scroll-sync#onEditorScroll typewriter:toggled->app#onTypewriterToggled">
+         data-action="codemirror:change->app#onEditorChange codemirror:selection-change->app#onEditorSelectionChange codemirror:scroll->scroll-sync#onEditorScroll codemirror:image-pasted->app#onImagePaste typewriter:toggled->app#onTypewriterToggled">
       <div class="h-full flex editor-wrapper" data-app-target="editorWrapper" data-typewriter-target="wrapper">
         <div class="flex-1 h-full editor-body" data-app-target="editorBody" data-typewriter-target="body">
           <!-- CodeMirror container -->

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -233,7 +233,7 @@ en:
       # Drag-and-drop
       drop_hint: "Drag & drop an image here"
       drop_rejected: "%{name}: %{ext} is not an accepted image type. Accepted: %{list}"
-      processing: "Processing image..."
+      processing_image_paste: "Processing image..."
       # Local images
       local_path_required: "Local Images Path Required"
       local_path_description: "To browse local images, configure an images directory path."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -233,6 +233,7 @@ en:
       # Drag-and-drop
       drop_hint: "Drag & drop an image here"
       drop_rejected: "%{name}: %{ext} is not an accepted image type. Accepted: %{list}"
+      processing: "Processing image..."
       # Local images
       local_path_required: "Local Images Path Required"
       local_path_description: "To browse local images, configure an images directory path."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -213,6 +213,7 @@ es:
       tab_drop: "Soltar"
       drop_hint: "Arrastra y suelta una imagen aquí"
       drop_rejected: "%{name}: %{ext} no es un tipo de imagen aceptado. Aceptados: %{list}"
+      processing: "Procesando imagen..."
       tab_local: "Local"
       tab_folder: "Carpeta"
       tab_web: "Búsqueda Web"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -213,7 +213,7 @@ es:
       tab_drop: "Soltar"
       drop_hint: "Arrastra y suelta una imagen aquí"
       drop_rejected: "%{name}: %{ext} no es un tipo de imagen aceptado. Aceptados: %{list}"
-      processing: "Procesando imagen..."
+      processing_image_paste: "Procesando imagen..."
       tab_local: "Local"
       tab_folder: "Carpeta"
       tab_web: "Búsqueda Web"

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -210,6 +210,7 @@ he:
       tab_drop: "גרירה"
       drop_hint: "גררו ושחררו תמונה כאן"
       drop_rejected: "%{name}: %{ext} אינו סוג תמונה מקובל. מקובלים: %{list}"
+      processing: "מעבד תמונה..."
       tab_local: "מקומי"
       tab_folder: "תיקייה"
       tab_web: "חיפוש באינטרנט"

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -210,7 +210,7 @@ he:
       tab_drop: "גרירה"
       drop_hint: "גררו ושחררו תמונה כאן"
       drop_rejected: "%{name}: %{ext} אינו סוג תמונה מקובל. מקובלים: %{list}"
-      processing: "מעבד תמונה..."
+      processing_image_paste: "מעבד תמונה..."
       tab_local: "מקומי"
       tab_folder: "תיקייה"
       tab_web: "חיפוש באינטרנט"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -213,7 +213,7 @@ ja:
       tab_drop: "ドロップ"
       drop_hint: "ここに画像をドラッグ＆ドロップ"
       drop_rejected: "%{name}: %{ext} は受け付けられない画像形式です。受付可能: %{list}"
-      processing: "画像を処理中..."
+      processing_image_paste: "画像を処理中..."
       tab_local: "ローカル"
       tab_folder: "フォルダ"
       tab_web: "Web検索"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -213,6 +213,7 @@ ja:
       tab_drop: "ドロップ"
       drop_hint: "ここに画像をドラッグ＆ドロップ"
       drop_rejected: "%{name}: %{ext} は受け付けられない画像形式です。受付可能: %{list}"
+      processing: "画像を処理中..."
       tab_local: "ローカル"
       tab_folder: "フォルダ"
       tab_web: "Web検索"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -213,6 +213,7 @@ ko:
       tab_drop: "드롭"
       drop_hint: "여기에 이미지를 끌어다 놓으세요"
       drop_rejected: "%{name}: %{ext}은(는) 허용되지 않는 이미지 형식입니다. 허용: %{list}"
+      processing: "이미지 처리 중..."
       tab_local: "로컬"
       tab_folder: "폴더"
       tab_web: "웹 검색"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -213,7 +213,7 @@ ko:
       tab_drop: "드롭"
       drop_hint: "여기에 이미지를 끌어다 놓으세요"
       drop_rejected: "%{name}: %{ext}은(는) 허용되지 않는 이미지 형식입니다. 허용: %{list}"
-      processing: "이미지 처리 중..."
+      processing_image_paste: "이미지 처리 중..."
       tab_local: "로컬"
       tab_folder: "폴더"
       tab_web: "웹 검색"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -219,7 +219,7 @@ pt-BR:
       tab_drop: "Soltar"
       drop_hint: "Arraste e solte uma imagem aqui"
       drop_rejected: "%{name}: %{ext} não é um tipo de imagem aceito. Aceitos: %{list}"
-      processing: "Processando imagem..."
+      processing_image_paste: "Processando imagem..."
       tab_local: "Local"
       tab_folder: "Pasta"
       tab_web: "Busca Web"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -219,6 +219,7 @@ pt-BR:
       tab_drop: "Soltar"
       drop_hint: "Arraste e solte uma imagem aqui"
       drop_rejected: "%{name}: %{ext} não é um tipo de imagem aceito. Aceitos: %{list}"
+      processing: "Processando imagem..."
       tab_local: "Local"
       tab_folder: "Pasta"
       tab_web: "Busca Web"

--- a/config/locales/pt-PT.yml
+++ b/config/locales/pt-PT.yml
@@ -213,7 +213,7 @@ pt-PT:
       tab_drop: "Largar"
       drop_hint: "Arraste e largue uma imagem aqui"
       drop_rejected: "%{name}: %{ext} não é um tipo de imagem aceite. Aceites: %{list}"
-      processing: "A processar imagem..."
+      processing_image_paste: "A processar imagem..."
       tab_local: "Local"
       tab_folder: "Pasta"
       tab_web: "Pesquisa Web"

--- a/config/locales/pt-PT.yml
+++ b/config/locales/pt-PT.yml
@@ -213,6 +213,7 @@ pt-PT:
       tab_drop: "Largar"
       drop_hint: "Arraste e largue uma imagem aqui"
       drop_rejected: "%{name}: %{ext} não é um tipo de imagem aceite. Aceites: %{list}"
+      processing: "A processar imagem..."
       tab_local: "Local"
       tab_folder: "Pasta"
       tab_web: "Pesquisa Web"

--- a/test/i18n_media_upload_keys_test.rb
+++ b/test/i18n_media_upload_keys_test.rb
@@ -14,6 +14,7 @@ class I18nMediaUploadKeysTest < ActiveSupport::TestCase
     "dialogs.image_picker.tab_drop",
     "dialogs.image_picker.drop_hint",
     "dialogs.image_picker.drop_rejected",
+    "dialogs.image_picker.processing",
     "dialogs.video.tab_drop",
     "dialogs.video.drop_hint",
     "dialogs.video.drop_rejected",

--- a/test/i18n_media_upload_keys_test.rb
+++ b/test/i18n_media_upload_keys_test.rb
@@ -14,7 +14,7 @@ class I18nMediaUploadKeysTest < ActiveSupport::TestCase
     "dialogs.image_picker.tab_drop",
     "dialogs.image_picker.drop_hint",
     "dialogs.image_picker.drop_rejected",
-    "dialogs.image_picker.processing",
+    "dialogs.image_picker.processing_image_paste",
     "dialogs.video.tab_drop",
     "dialogs.video.drop_hint",
     "dialogs.video.drop_rejected",

--- a/test/javascript/controllers/drop_images_controller.test.js
+++ b/test/javascript/controllers/drop_images_controller.test.js
@@ -105,6 +105,29 @@ describe("DropImagesController", () => {
     })
   })
 
+  describe("loadExternalFile()", () => {
+    it("ingests a pasted file and auto-selects it", async () => {
+      const dispatchSpy = vi.spyOn(controller, "dispatch")
+      await controller.loadExternalFile(file("pasted.png"))
+
+      expect(controller.selectedImage).toMatchObject({ name: "pasted.png" })
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        "selected",
+        expect.objectContaining({ detail: expect.objectContaining({ type: "drop", name: "pasted.png" }) })
+      )
+      expect(controller.gridTarget.querySelector('[data-index="0"]').classList.contains("selected")).toBe(true)
+    })
+
+    it("selects nothing and shows feedback when the file is rejected", async () => {
+      const dispatchSpy = vi.spyOn(controller, "dispatch")
+      await controller.loadExternalFile(file("notes.txt"))
+
+      expect(controller.selectedImage).toBeNull()
+      expect(dispatchSpy).not.toHaveBeenCalledWith("selected", expect.anything())
+      expect(controller.feedbackTarget.classList.contains("hidden")).toBe(false)
+    })
+  })
+
   describe("onDropzoneKeydown()", () => {
     it("opens the picker on Enter and Space, ignores others", () => {
       const spy = vi.spyOn(controller, "openPicker").mockImplementation(() => {})

--- a/test/javascript/controllers/image_picker_controller.test.js
+++ b/test/javascript/controllers/image_picker_controller.test.js
@@ -1,0 +1,73 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import ImagePickerController from "../../../app/javascript/controllers/image_picker_controller.js"
+
+describe("ImagePickerController#openWithFile", () => {
+  let application, controller, element
+
+  beforeEach(() => {
+    window.t = vi.fn((key) => key)
+    // connect() loads /images/config; return a minimal config.
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ s3_enabled: false, image_extensions: [".png"] })
+    })
+
+    document.body.innerHTML = `
+      <div data-controller="image-picker">
+        <dialog data-image-picker-target="dialog"></dialog>
+        <div data-image-picker-target="loading" class="hidden">
+          <span data-image-picker-target="loadingText"></span>
+        </div>
+      </div>
+    `
+
+    element = document.querySelector('[data-controller="image-picker"]')
+    application = Application.start()
+    application.register("image-picker", ImagePickerController)
+
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        controller = application.getControllerForElementAndIdentifier(element, "image-picker")
+        // open() calls dialog.showModal(), unimplemented in jsdom — stub it out.
+        controller.open = vi.fn().mockResolvedValue()
+        resolve()
+      }, 0)
+    })
+  })
+
+  afterEach(() => {
+    application.stop()
+    vi.restoreAllMocks()
+  })
+
+  it("opens the picker and delegates the file to the Drop source with loading toggled", async () => {
+    const dropCtrl = { loadExternalFile: vi.fn().mockResolvedValue() }
+    controller.getSourceController = vi.fn(() => dropCtrl)
+    const showLoading = vi.spyOn(controller, "showLoading")
+    const hideLoading = vi.spyOn(controller, "hideLoading")
+
+    const file = { name: "pasted.png" }
+    await controller.openWithFile(file)
+
+    expect(controller.open).toHaveBeenCalled()
+    expect(controller.getSourceController).toHaveBeenCalledWith("drop-images")
+    expect(showLoading).toHaveBeenCalledWith("dialogs.image_picker.processing")
+    expect(dropCtrl.loadExternalFile).toHaveBeenCalledWith(file)
+    expect(hideLoading).toHaveBeenCalled()
+  })
+
+  it("bails without loading when the Drop source is unavailable", async () => {
+    controller.getSourceController = vi.fn(() => null)
+    const showLoading = vi.spyOn(controller, "showLoading")
+
+    await controller.openWithFile({ name: "pasted.png" })
+
+    expect(controller.open).toHaveBeenCalled()
+    expect(showLoading).not.toHaveBeenCalled()
+  })
+})

--- a/test/javascript/controllers/image_picker_controller.test.js
+++ b/test/javascript/controllers/image_picker_controller.test.js
@@ -56,7 +56,7 @@ describe("ImagePickerController#openWithFile", () => {
 
     expect(controller.open).toHaveBeenCalled()
     expect(controller.getSourceController).toHaveBeenCalledWith("drop-images")
-    expect(showLoading).toHaveBeenCalledWith("dialogs.image_picker.processing")
+    expect(showLoading).toHaveBeenCalledWith("dialogs.image_picker.processing_image_paste")
     expect(dropCtrl.loadExternalFile).toHaveBeenCalledWith(file)
     expect(hideLoading).toHaveBeenCalled()
   })

--- a/test/javascript/lib/clipboard_image.test.js
+++ b/test/javascript/lib/clipboard_image.test.js
@@ -1,0 +1,45 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from "vitest"
+import { imageFileFromClipboard, normalizeImageFile } from "../../../app/javascript/lib/clipboard_image.js"
+
+function item(kind, type, file) {
+  return { kind, type, getAsFile: () => file }
+}
+
+describe("imageFileFromClipboard()", () => {
+  it("returns the image File when the clipboard carries one", () => {
+    const png = new File(["x"], "shot.png", { type: "image/png" })
+    const result = imageFileFromClipboard({ items: [item("file", "image/png", png)] })
+    expect(result).toBeInstanceOf(File)
+    expect(result.name).toBe("shot.png")
+  })
+
+  it("skips non-file and non-image items", () => {
+    const items = [
+      item("string", "text/plain", null),
+      item("file", "application/pdf", new File(["x"], "doc.pdf", { type: "application/pdf" }))
+    ]
+    expect(imageFileFromClipboard({ items })).toBeNull()
+  })
+
+  it("returns null for empty or missing clipboard data", () => {
+    expect(imageFileFromClipboard(null)).toBeNull()
+    expect(imageFileFromClipboard({ items: [] })).toBeNull()
+  })
+})
+
+describe("normalizeImageFile()", () => {
+  it("synthesizes a filename with an extension from the MIME type", () => {
+    const blob = new File(["x"], "", { type: "image/png" })
+    const result = normalizeImageFile(blob)
+    expect(result.name).toMatch(/^pasted-image-.*\.png$/)
+    expect(result.type).toBe("image/png")
+  })
+
+  it("leaves a file that already has an extension untouched", () => {
+    const named = new File(["x"], "photo.jpg", { type: "image/jpeg" })
+    expect(normalizeImageFile(named)).toBe(named)
+  })
+})


### PR DESCRIPTION
## What

Adds handling for pasting (Ctrl/Cmd + V) images while on the editor. Users can paste an image while typing on the editor and have their image uploaded.

## Preview

https://github.com/user-attachments/assets/239a2717-fa5c-46a8-b79a-b037d41b65e6

## Why
It's pretty common for screenshot apps to write the image into the clipboard rather than storing it in a file, so handling pasting seems like a good enhancement. 
Follows the same idea from #112: making it easier for the user to upload media while remotely using/editing the editor. 