### PR TITLE
fix(security): enforce CSRF on upload endpoints

### DIFF
--- a/app/controllers/ai_controller.rb
+++ b/app/controllers/ai_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class AiController < ApplicationController
-  skip_forgery_protection only: [ :fix_grammar, :generate_image ]
-
   # GET /ai/config
   def status
     render json: AiService.provider_info

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -4,7 +4,6 @@ require "net/http"
 require "json"
 
 class ImagesController < ApplicationController
-  skip_forgery_protection only: [ :upload, :upload_to_s3, :upload_external_to_s3, :upload_base64 ]
   before_action :require_images_enabled, except: [ :status, :upload, :upload_base64, :search_google, :search_pinterest ]
 
   # GET /images/config

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class MediaController < ApplicationController
-  skip_forgery_protection only: [ :upload ]
-
   # POST /media/upload
   # Upload a video file from browser drag-and-drop
   def upload

--- a/test/controllers/upload_csrf_test.rb
+++ b/test/controllers/upload_csrf_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The upload endpoints used to `skip_forgery_protection`, which — combined with
+# the editable S3 destination key (#117) — let a cross-site POST target any key
+# in the configured bucket. They now inherit CSRF protection like every other
+# mutating action; the in-app clients already send the token via @rails/request.js.
+class UploadCsrfTest < ActionDispatch::IntegrationTest
+  # Integration tests disable forgery protection globally; turn it back on so we
+  # exercise the real check instead of the test-env bypass.
+  setup do
+    @forgery_was = ActionController::Base.allow_forgery_protection
+    ActionController::Base.allow_forgery_protection = true
+  end
+
+  teardown do
+    ActionController::Base.allow_forgery_protection = @forgery_was
+  end
+
+  PROTECTED_POSTS = [
+    "/images/upload",
+    "/images/upload_to_s3",
+    "/images/upload_external_to_s3",
+    "/images/upload_base64",
+    "/media/upload",
+    "/ai/fix_grammar",
+    "/ai/generate_image"
+  ].freeze
+
+  PROTECTED_POSTS.each do |path|
+    test "#{path} rejects a POST without a CSRF token" do
+      post path
+      assert_response :unprocessable_entity,
+        "#{path} must enforce CSRF protection"
+    end
+  end
+end


### PR DESCRIPTION
## What

The upload endpoints no longer skip CSRF protection. `skip_forgery_protection`
is removed from every upload action so they inherit the same forgery check as
the rest of the app:

- `ImagesController` — `upload`, `upload_to_s3`, `upload_external_to_s3`, `upload_base64`
- `MediaController` — `upload`
- `AiController` — `fix_grammar`, `generate_image`

Closes #118.

## Why

#117 made the S3 destination key editable. With the endpoints CSRF-exempt, a
cross-site POST to a user's FrankMD (localhost / LAN / tunnel) could now pass an
arbitrary `s3_key` — upgrading the blast radius from "write junk under
`frankmd/YYYY/MM/`" to "overwrite any object in the configured bucket". The skip
was never load-bearing: it looks inherited/cargo-culted, not required.

## How

- Removed the three `skip_forgery_protection` declarations. Nothing replaces
  them — the actions now use the app-wide default.
- No client change needed: every in-app caller already posts through
  `@rails/request.js`, which attaches `X-CSRF-Token` from the `csrf_meta_tags`
  in the layout — the exact mechanism the note-save PATCH (never exempt) relies
  on. Verified the callers: `folder_images.js`, `local_images.js`,
  `web_images.js`, `ai_images.js`, `video_dialog_controller.js`,
  `ai_grammar_controller.js` all use `post` from `@rails/request.js`.
- The reverse-proxy nuance from #63 still holds: production keeps
  `forgery_protection_origin_check = false`, so token validation is the only
  check applied — which is what we want here.

## Testing

- New `test/controllers/upload_csrf_test.rb` turns `allow_forgery_protection`
  back on (integration tests disable it globally) and asserts each of the seven
  upload endpoints rejects a token-less POST with `422`. Guards against the skip
  being reintroduced.
- Existing controller tests still pass; they run with forgery protection off
  (test-env default), matching how the in-app clients behave with a valid token.

> Pre-existing note: a handful of `*_controller_test` assertions fail on this
> repo regardless of this branch because the dev/test locale defaults to pt-BR
> (they assert English error strings). Unrelated to this change — the CSRF and
> happy-path upload assertions all pass.
