### PR TITLE
fix(security): contain paths by ancestry, not string prefix

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -149,10 +149,9 @@ class NotesController < ApplicationController
 
   def serve_asset(path)
     notes_path = Pathname.new(ENV.fetch("NOTES_PATH", Rails.root.join("notes")))
-    full_path = notes_path.join(path).cleanpath
+    full_path = PathSafety.contain(notes_path, path)
 
-    # Prevent path traversal
-    unless full_path.to_s.start_with?(notes_path.to_s)
+    if full_path.nil?
       head :forbidden
       return
     end

--- a/app/services/images_service.rb
+++ b/app/services/images_service.rb
@@ -280,16 +280,7 @@ class ImagesService
     def safe_path(path)
       return nil if path.blank?
 
-      # Prevent path traversal
-      clean_path = Pathname.new(path).cleanpath
-      return nil if clean_path.to_s.start_with?("..")
-
-      full_path = images_path.join(clean_path)
-
-      # Ensure the path is within images_path
-      return nil unless full_path.to_s.start_with?(images_path.to_s)
-
-      full_path
+      PathSafety.contain(images_path, path)
     end
 
     def content_type_for(path)

--- a/app/services/notes_service.rb
+++ b/app/services/notes_service.rb
@@ -179,12 +179,8 @@ class NotesService
   end
 
   def safe_path(path, must_exist: true)
-    normalized = Pathname.new(path.to_s.gsub(/\.\./, "")).cleanpath
-    full_path = @base_path.join(normalized)
-
-    unless full_path.to_s.start_with?(@base_path.to_s)
-      raise InvalidPathError, "Invalid path: #{path}"
-    end
+    full_path = PathSafety.contain(@base_path, path)
+    raise InvalidPathError, "Invalid path: #{path}" if full_path.nil?
 
     if must_exist && !full_path.exist?
       raise NotFoundError, "Path not found: #{path}"

--- a/app/services/path_safety.rb
+++ b/app/services/path_safety.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Single source of truth for containing a user-supplied path inside a base
+# directory. Prevents:
+#   - traversal via "../" and absolute-path escapes (Pathname#join with an
+#     absolute path replaces the base; cleanpath resolves ".." lexically);
+#   - the sibling-prefix bypass a raw String#start_with? allows, e.g. base
+#     "/data/notes" wrongly accepting "/data/notes-backup/secret" — the check
+#     is anchored on a directory separator;
+#   - symlinks inside the tree that resolve outside it (validated via realpath).
+#
+# Returns the cleaned, contained Pathname, or nil if the path would escape.
+module PathSafety
+  module_function
+
+  def contain(base, path)
+    return nil if path.nil?
+
+    base = Pathname.new(base).cleanpath
+    candidate = base.join(path.to_s).cleanpath
+    return nil unless within?(candidate, base)
+
+    # cleanpath is lexical, so a symlink chain could still resolve outside base.
+    # When both ends exist, re-check against the real (link-resolved) paths.
+    if candidate.exist? && base.exist?
+      return nil unless within?(candidate.realpath, base.realpath)
+    end
+
+    candidate
+  end
+
+  # True when `path` is `base` itself or strictly inside it (separator-anchored,
+  # so a sibling directory sharing the name prefix does not pass).
+  def within?(path, base)
+    path == base || path.to_s.start_with?(base.to_s + File::SEPARATOR)
+  end
+end

--- a/test/services/notes_service_test.rb
+++ b/test/services/notes_service_test.rb
@@ -277,14 +277,21 @@ class NotesServiceTest < ActiveSupport::TestCase
     end
   end
 
-  test "sanitizes paths with double dots" do
-    # The service should either reject or sanitize paths with ..
+  test "rejects paths that traverse out of the base directory" do
     create_test_note("safe.md", "Safe content")
 
-    # This should not allow escaping the base directory
-    assert_raises(NotesService::NotFoundError) do
+    # ".." that escapes the base is rejected outright, not silently sanitized
+    # (the old gsub approach also mangled legitimate filenames containing "..").
+    assert_raises(NotesService::InvalidPathError) do
       @service.read("folder/../../../etc/passwd")
     end
+  end
+
+  test "allows a filename that legitimately contains double dots" do
+    @service.write("notes..v2.md", "kept intact")
+
+    assert_equal "kept intact", @service.read("notes..v2.md")
+    assert @test_notes_dir.join("notes..v2.md").exist?
   end
 
   # === search_content ===

--- a/test/services/path_safety_test.rb
+++ b/test/services/path_safety_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PathSafetyTest < ActiveSupport::TestCase
+  BASE = "/data/notes"
+
+  test "contains a plain path inside base" do
+    assert_equal Pathname.new("/data/notes/note.md"), PathSafety.contain(BASE, "note.md")
+  end
+
+  test "contains a nested path inside base" do
+    assert_equal Pathname.new("/data/notes/a/b.md"), PathSafety.contain(BASE, "a/b.md")
+  end
+
+  test "rejects ../ traversal" do
+    assert_nil PathSafety.contain(BASE, "../../etc/passwd")
+  end
+
+  test "rejects an absolute path outside base" do
+    assert_nil PathSafety.contain(BASE, "/etc/passwd")
+  end
+
+  test "rejects a sibling directory that shares the name prefix" do
+    # The exact bypass a raw String#start_with? allowed: base /data/notes wrongly
+    # accepting /data/notes-backup because the string prefix matched.
+    assert_nil PathSafety.contain(BASE, "/data/notes-backup/secret.md")
+    assert_nil PathSafety.contain(BASE, "/data/notesX")
+  end
+
+  test "allows a filename that legitimately contains dot-dot" do
+    # The old gsub(/\.\./, "") mangled "notes..v2.md" into "notesv2.md".
+    assert_equal Pathname.new("/data/notes/notes..v2.md"), PathSafety.contain(BASE, "notes..v2.md")
+  end
+
+  test "returns nil for a nil path" do
+    assert_nil PathSafety.contain(BASE, nil)
+  end
+
+  test "rejects a symlink that resolves outside base" do
+    Dir.mktmpdir do |raw|
+      tmp = File.realpath(raw) # resolve /tmp -> /private/tmp on macOS
+      base = File.join(tmp, "notes")
+      outside = File.join(tmp, "outside")
+      FileUtils.mkdir_p(base)
+      FileUtils.mkdir_p(outside)
+      File.write(File.join(outside, "secret.txt"), "x")
+      File.symlink(File.join(outside, "secret.txt"), File.join(base, "link.txt"))
+
+      assert_nil PathSafety.contain(base, "link.txt")
+    end
+  end
+
+  test "allows a real file inside base" do
+    Dir.mktmpdir do |raw|
+      tmp = File.realpath(raw)
+      base = File.join(tmp, "notes")
+      FileUtils.mkdir_p(base)
+      File.write(File.join(base, "ok.md"), "x")
+
+      assert_equal Pathname.new(File.join(base, "ok.md")), PathSafety.contain(base, "ok.md")
+    end
+  end
+end


### PR DESCRIPTION
### Problem
The three path guards — `NotesService#safe_path`, `ImagesService.safe_path`, and `NotesController#serve_asset` — each checked containment with `full_path.to_s.start_with?(base.to_s)`, a raw string prefix. Because that isn't anchored on a directory separator, base `/data/notes` accepts a sibling directory such as `/data/notes-backup/secret`. In addition, `serve_asset` took the raw `params[:path]` without stripping `..`, and `NotesService` stripped `..` with a `gsub` that also mangled legitimate filenames (`notes..v2.md` → `notesv2.md`).

### Fix
Introduces a single `PathSafety.contain` helper used by all three call sites:

- containment is anchored on a directory separator (no sibling-prefix bypass);
- `..` is resolved via `cleanpath` (no `gsub` mangling) and absolute-path escapes are rejected;
- `realpath` is re-checked when the path exists, so a symlink inside the tree cannot resolve outside it.

### Testing
`bin/rails test` — a dedicated `PathSafety` unit test covers the sibling-prefix bypass, absolute escape, `..` traversal, a symlink resolving outside the base, and a legitimate `..` filename. The existing traversal tests were updated to expect outright rejection rather than silent sanitization.
