### PR TITLE
fix(uploads): enforce the image allow-list on base64 uploads (stored XSS)

### DIFF
--- a/app/services/images_service.rb
+++ b/app/services/images_service.rb
@@ -166,6 +166,13 @@ class ImagesService
         filename = "#{filename}#{extension}"
       end
 
+      # Enforce the same allow-list + size cap as the multipart upload path. This
+      # route previously skipped both, so mime_type=image/svg+xml (-> .svg) or a
+      # caller-supplied .html filename could be stored under the notes dir and
+      # served inline by NotesController#serve_asset (stored XSS). See UploadStorage.
+      UploadStorage.enforce_bytes!(file_content.bytesize)
+      UploadStorage.validate_filename!(filename, "image_upload_extensions", "image")
+
       # Create temp file
       temp_dir = Rails.root.join("tmp", "uploads")
       FileUtils.mkdir_p(temp_dir)
@@ -181,6 +188,8 @@ class ImagesService
       ensure
         FileUtils.rm_f(temp_path)
       end
+    rescue UploadStorage::RejectedError => e
+      { error: e.message }
     end
 
     def download_and_upload_to_s3(url, resize: nil, custom_prefix: nil)

--- a/app/services/upload_storage.rb
+++ b/app/services/upload_storage.rb
@@ -31,7 +31,14 @@ module UploadStorage
   # Returns the normalized (downcased) extension, or raises RejectedError with
   # a user-facing message. `kind` is "image" or "video" for the message.
   def validate_extension!(uploaded_file, config_key, kind)
-    extension = File.extname(uploaded_file.original_filename.to_s).downcase
+    validate_filename!(uploaded_file.original_filename.to_s, config_key, kind)
+  end
+
+  # Same allow-list check for a bare filename string — for uploads that have no
+  # UploadedFile object (e.g. base64 / AI-generated images). Returns the
+  # normalized (downcased) extension, or raises RejectedError.
+  def validate_filename!(filename, config_key, kind)
+    extension = File.extname(filename.to_s).downcase
     allowed = Config.new.upload_extensions(config_key)
     unless allowed.include?(extension)
       shown = extension.presence || "no extension"
@@ -44,6 +51,11 @@ module UploadStorage
   # or copy them to disk.
   def enforce_size!(uploaded_file)
     size = uploaded_file.size if uploaded_file.respond_to?(:size)
+    enforce_bytes!(size)
+  end
+
+  # Same cap for an already-known byte size (e.g. decoded base64 content).
+  def enforce_bytes!(size)
     return unless size && size > MAX_UPLOAD_BYTES
 
     raise RejectedError, "File is too large (max #{MAX_UPLOAD_BYTES / (1024 * 1024)} MB)."

--- a/test/services/images_service_test.rb
+++ b/test/services/images_service_test.rb
@@ -12,6 +12,7 @@ class ImagesServiceTest < ActiveSupport::TestCase
     @config_stub = stub("config")
     @config_stub.stubs(:get).returns(nil)
     @config_stub.stubs(:get).with("images_path").returns(@temp_dir.to_s)
+    @config_stub.stubs(:upload_extensions).with("image_upload_extensions").returns(%w[.jpg .jpeg .png .gif .webp .bmp])
     Config.stubs(:new).returns(@config_stub)
   end
 
@@ -174,6 +175,28 @@ class ImagesServiceTest < ActiveSupport::TestCase
     result = ImagesService.upload_base64_data("not valid base64!!!", mime_type: "image/png")
     assert result[:error]
     assert_includes result[:error], "Invalid base64"
+  end
+
+  test "upload_base64_data rejects an SVG mime type (stored-XSS vector)" do
+    svg = Base64.strict_encode64("<svg xmlns='http://www.w3.org/2000/svg'><script>alert(1)</script></svg>")
+    notes_dir = Pathname.new(ENV.fetch("NOTES_PATH", Rails.root.join("notes"))).join("images")
+    before = Dir.glob(notes_dir.join("*").to_s).size
+
+    result = ImagesService.upload_base64_data(svg, mime_type: "image/svg+xml", filename: "x.svg")
+
+    assert result[:error], "SVG upload must be rejected (not in the image allow-list)"
+    assert_includes result[:error], "not an accepted"
+    assert_equal before, Dir.glob(notes_dir.join("*").to_s).size,
+      "a rejected upload must not write a file under the notes dir"
+  end
+
+  test "upload_base64_data rejects an html filename (stored-XSS vector)" do
+    data = Base64.strict_encode64("<html><script>alert(1)</script></html>")
+
+    result = ImagesService.upload_base64_data(data, mime_type: "image/png", filename: "evil.html")
+
+    assert result[:error], "an .html filename must be rejected"
+    assert_includes result[:error], "not an accepted"
   end
 
   test "upload_base64_data generates filename when not provided" do


### PR DESCRIPTION
### Problem
`ImagesService.upload_base64_data` writes the decoded bytes to the notes directory **without** `UploadStorage`'s extension allow-list or size cap — unlike the multipart path (`upload_file`). So `mime_type=image/svg+xml` (→ `.svg`), or a caller-supplied `.html` filename, is stored under the notes dir and served inline by `NotesController#serve_asset`, executing scripts in the app origin (CSP is disabled). This is exactly the vector `UploadStorage`'s header comment says it exists to close — the multipart hole was closed, the base64 one was left open.

### Fix
Extracts `UploadStorage.validate_filename!` + `enforce_bytes!` (so both upload paths share one allow-list) and runs them on the base64 route before anything is written. Disallowed types (`.svg`, `.html`, …) are rejected with the same user-facing message as the multipart path.

### Testing
`bin/rails test` — a base64 upload with an SVG mime type, or an `.html` filename, is rejected and writes nothing under the notes dir; a valid PNG still succeeds.
