### PR TITLE
fix(notes): write notes atomically to survive interrupted writes

### DIFF
--- a/app/services/notes_service.rb
+++ b/app/services/notes_service.rb
@@ -23,7 +23,7 @@ class NotesService
   def write(path, content)
     full_path = safe_path(path, must_exist: false)
     FileUtils.mkdir_p(full_path.dirname)
-    full_path.write(content)
+    atomic_write(full_path, content)
     true
   end
 
@@ -116,6 +116,22 @@ class NotesService
   end
 
   private
+
+  # Write atomically: write to a temp file in the same directory, then rename it
+  # over the target. A failed or partial write (e.g. ENOSPC / disk full) never
+  # leaves the existing note truncated — the original stays intact until the
+  # atomic rename succeeds. The temp file is on the same filesystem as the
+  # target, so File.rename is atomic.
+  def atomic_write(full_path, content)
+    tmp = full_path.dirname.join(".#{full_path.basename}.#{SecureRandom.hex(6)}.tmp")
+    begin
+      tmp.write(content)
+      File.rename(tmp.to_s, full_path.to_s)
+    rescue StandardError
+      tmp.delete if tmp.exist?
+      raise
+    end
+  end
 
   # Collect files sorted by modification time (for file finder/tree display)
   def collect_markdown_files(dir)

--- a/test/services/notes_service_test.rb
+++ b/test/services/notes_service_test.rb
@@ -157,6 +157,26 @@ class NotesServiceTest < ActiveSupport::TestCase
     assert @test_notes_dir.join("deep/nested/note.md").exist?
   end
 
+  test "write does not leave temp files behind" do
+    @service.write("note.md", "content")
+
+    temps = Dir.children(@test_notes_dir).select { |f| f.end_with?(".tmp") }
+    assert_empty temps, "atomic write should clean up its temp file"
+  end
+
+  test "write preserves the original note when the atomic rename fails" do
+    create_test_note("note.md", "Original content")
+    File.stubs(:rename).raises(Errno::ENOSPC)
+
+    assert_raises(Errno::ENOSPC) { @service.write("note.md", "New content that fails") }
+
+    # The write was atomic: the original is untouched (not truncated/corrupted)
+    # and the temp file was cleaned up.
+    assert_equal "Original content", File.read(@test_notes_dir.join("note.md"))
+    temps = Dir.children(@test_notes_dir).select { |f| f.end_with?(".tmp") }
+    assert_empty temps, "failed atomic write should not leave a temp file behind"
+  end
+
   test "write creates Hugo blog post directory structure" do
     # Hugo blog posts use YYYY/MM/DD/slug/index.md structure
     hugo_path = "2026/01/30/my-first-post/index.md"


### PR DESCRIPTION
### Problem
`NotesService#write` used `Pathname#write`, which truncates then writes in place. A failed or partial write — e.g. disk full (`ENOSPC`) mid-write — leaves the note truncated and corrupted on disk, and the only intact copy is the in-memory buffer.

### Fix
Writes to a temp file in the same directory, then `File.rename`s it over the target (atomic on the same filesystem). The original stays intact until the rename succeeds; the temp file is cleaned up if the write fails.

### Testing
`bin/rails test` — a write whose rename fails (stubbed `ENOSPC`) leaves the original content untouched and no temp file behind; a normal write leaves no temp files.
