### PR TITLE
fix(notes): keep content search working on invalid-UTF-8 files

### DIFF
--- a/app/services/notes_service.rb
+++ b/app/services/notes_service.rb
@@ -153,7 +153,10 @@ class NotesService
 
   def search_file(file_path, regex, context_lines, max_matches)
     matches = []
-    lines = file_path.readlines(chomp: true)
+    # scrub replaces invalid UTF-8 bytes with the replacement character, so a
+    # single Latin-1/binary .md file cannot raise "invalid byte sequence in
+    # UTF-8" from line.match? and take down the entire content search.
+    lines = file_path.readlines(chomp: true).map(&:scrub)
 
     lines.each_with_index do |line, index|
       next unless line.match?(regex)
@@ -176,6 +179,10 @@ class NotesService
     end
 
     matches
+  rescue SystemCallError
+    # File vanished between listing and read (TOCTOU), or another I/O error —
+    # skip this file rather than failing the whole search.
+    []
   end
 
   def safe_path(path, must_exist: true)

--- a/test/services/notes_service_test.rb
+++ b/test/services/notes_service_test.rb
@@ -313,6 +313,23 @@ class NotesServiceTest < ActiveSupport::TestCase
     assert_equal 1, results.length
   end
 
+  test "search_content does not fail on a file with invalid UTF-8 bytes" do
+    # A Latin-1/binary .md anywhere in the tree must not take down the whole search.
+    File.binwrite(@test_notes_dir.join("bad.md"), "hello \xFF\xFE world\n")
+    create_test_note("good.md", "hello world")
+
+    results = nil
+    assert_nothing_raised { results = @service.search_content("world") }
+    assert_includes results.map { |r| r[:path] }, "good.md"
+  end
+
+  test "search_content matches text in a file with invalid UTF-8, scrubbing bad bytes" do
+    File.binwrite(@test_notes_dir.join("bad.md"), "target_word \xFF here\n")
+
+    results = @service.search_content("target_word")
+    assert_includes results.map { |r| r[:path] }, "bad.md"
+  end
+
   test "search_content supports regex patterns" do
     create_test_note("note.md", "foo123bar\nfoo456bar\nhello world")
 


### PR DESCRIPTION
### Problem
`search_file` called `line.match?` on raw `readlines`, so a single Latin-1/binary `.md` file anywhere in the tree raised `ArgumentError: invalid byte sequence in UTF-8` — taking down the **entire** content search, not just that one file.

### Fix
`scrub`s each line before matching (invalid bytes → replacement character). A per-file `rescue SystemCallError` also skips a file that vanished mid-search (TOCTOU) instead of failing the whole query.

### Testing
`bin/rails test` — content search over a tree containing a binary `.md` no longer raises and still returns matches from the valid files; text before the bad bytes in a scrubbed file is still matchable.
