### PR TITLE
feat(files): show where a new note/folder will be created

### DIFF
--- a/app/javascript/controllers/file_operations_controller.js
+++ b/app/javascript/controllers/file_operations_controller.js
@@ -14,7 +14,8 @@ export default class extends Controller {
     "noteTypeDialog",
     "newItemDialog",
     "newItemTitle",
-    "newItemInput"
+    "newItemInput",
+    "newItemLocation"
   ]
 
   connect() {
@@ -172,6 +173,14 @@ export default class extends Controller {
     if (this.hasNewItemTitleTarget) {
       const titleKey = type === "folder" ? "dialogs.new_item.new_folder" : "dialogs.new_item.new_note"
       this.newItemTitleTarget.textContent = window.t(titleKey)
+    }
+
+    if (this.hasNewItemLocationTarget) {
+      const where = this.newItemParent && this.newItemParent.length
+        ? this.newItemParent
+        : window.t("dialogs.new_item.root_location")
+      this.newItemLocationTarget.textContent = `${window.t("dialogs.new_item.creating_in")} ${where}`
+      this.newItemLocationTarget.title = where
     }
 
     if (this.hasNewItemInputTarget) {

--- a/app/views/notes/dialogs/_file_operations.html.erb
+++ b/app/views/notes/dialogs/_file_operations.html.erb
@@ -118,7 +118,11 @@
     data-file-operations-target="newItemDialog"
   >
     <form method="dialog" class="p-4 w-80 text-[var(--theme-text-primary)]">
-      <h3 class="text-sm font-semibold mb-3" data-file-operations-target="newItemTitle"><%= t('dialogs.new_item.new_note') %></h3>
+      <h3 class="text-sm font-semibold mb-1" data-file-operations-target="newItemTitle"><%= t('dialogs.new_item.new_note') %></h3>
+      <p
+        class="text-xs text-[var(--theme-text-muted)] mb-3 truncate"
+        data-file-operations-target="newItemLocation"
+      ></p>
       <input
         type="text"
         data-file-operations-target="newItemInput"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -144,6 +144,8 @@ en:
       placeholder: "Name"
       note_placeholder: "Note name"
       folder_placeholder: "Folder name"
+      creating_in: "In:"
+      root_location: "root folder"
 
     # Note type dialog
     note_type:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -138,6 +138,8 @@ es:
       placeholder: "Nombre"
       note_placeholder: "Nombre de la nota"
       folder_placeholder: "Nombre de la carpeta"
+      creating_in: "En:"
+      root_location: "carpeta raíz"
 
     # Note type dialog
     note_type:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -135,6 +135,8 @@ he:
       placeholder: "שם"
       note_placeholder: "שם ההערה"
       folder_placeholder: "שם התיקייה"
+      creating_in: "ב־"
+      root_location: "תיקיית השורש"
 
     # דיאלוג סוג הערה
     note_type:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -138,6 +138,8 @@ ja:
       placeholder: "名前"
       note_placeholder: "ノート名"
       folder_placeholder: "フォルダ名"
+      creating_in: "作成先:"
+      root_location: "ルートフォルダ"
 
     # Note type dialog
     note_type:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -138,6 +138,8 @@ ko:
       placeholder: "이름"
       note_placeholder: "노트 이름"
       folder_placeholder: "폴더 이름"
+      creating_in: "위치:"
+      root_location: "루트 폴더"
 
     # 노트 유형 다이얼로그
     note_type:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -144,6 +144,8 @@ pt-BR:
       placeholder: "Nome"
       note_placeholder: "Nome da nota"
       folder_placeholder: "Nome da pasta"
+      creating_in: "Em:"
+      root_location: "pasta raiz"
 
     # Diálogo de tipo de nota
     note_type:

--- a/config/locales/pt-PT.yml
+++ b/config/locales/pt-PT.yml
@@ -138,6 +138,8 @@ pt-PT:
       placeholder: "Nome"
       note_placeholder: "Nome da nota"
       folder_placeholder: "Nome da pasta"
+      creating_in: "Em:"
+      root_location: "pasta raiz"
 
     # Diálogo de tipo de nota
     note_type:

--- a/test/javascript/controllers/file_operations_controller.test.js
+++ b/test/javascript/controllers/file_operations_controller.test.js
@@ -32,6 +32,7 @@ describe("FileOperationsController", () => {
         <dialog data-file-operations-target="noteTypeDialog"></dialog>
         <dialog data-file-operations-target="newItemDialog">
           <h3 data-file-operations-target="newItemTitle"></h3>
+          <p data-file-operations-target="newItemLocation"></p>
           <input data-file-operations-target="newItemInput" type="text" />
         </dialog>
       </div>
@@ -195,6 +196,21 @@ describe("FileOperationsController", () => {
       controller.newFolder()
 
       expect(openSpy).toHaveBeenCalledWith("folder", "")
+    })
+  })
+
+  describe("openNewItemDialog() location", () => {
+    it("shows the parent path when creating inside a folder", () => {
+      controller.openNewItemDialog("folder", "docs/guides")
+
+      expect(controller.newItemLocationTarget.textContent).toContain("docs/guides")
+      expect(controller.newItemLocationTarget.title).toBe("docs/guides")
+    })
+
+    it("shows the root location label when creating at the root", () => {
+      controller.openNewItemDialog("folder", "")
+
+      expect(controller.newItemLocationTarget.textContent).toContain("dialogs.new_item.root_location")
     })
   })
 


### PR DESCRIPTION
### What
The New Note / New Folder dialog now shows where the item will be created — `In: docs/guides`, or `In: root folder` at the top level.

### Why
The dialog only asked for a name, with no indication of the target directory. Opened from the global New button it creates at the root; opened from a folder's context menu it creates inside that folder — but nothing showed which, so it was easy to create things in the wrong place.

### How
`file_operations_controller#openNewItemDialog` already knows the parent path; it now writes it into a small location line in the dialog. Adds `creating_in` and `root_location` keys across all 7 locales.

### Testing
`npx vitest run` — added a spec covering the location line (parent path shown when creating inside a folder; root label at the top level).
