### PR TITLE
fix(test): stop tests leaking I18n.locale into each other

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,6 +31,15 @@ module ActiveSupport
     # Run tests in parallel with specified workers
     parallelize(workers: :number_of_processors)
 
+    # ApplicationController#set_locale assigns the global I18n.locale on every
+    # request, so a controller test that configures a non-English locale leaves
+    # it set for whatever test runs next in the same worker. A model test that
+    # asserts on an English error message then fails, depending on ordering.
+    # Restore the locale after every test so no test can leak it.
+    teardown do
+      I18n.locale = I18n.default_locale
+    end
+
     # Create a temporary notes directory for each test
     def setup_test_notes_dir
       @original_notes_path = ENV["NOTES_PATH"]


### PR DESCRIPTION
### Problem
`ApplicationController#set_locale` assigns the global `I18n.locale` on every request, so a controller test that exercises a non-English locale leaves it set for whatever test runs next in the same worker. A model test asserting on an English error message then fails depending on ordering — I saw `FolderTest#test_folder.destroy_handles_folder_that_disappeared` receive the Portuguese message ("Pasta não encontrada").

To be upfront: it is intermittent and I did not pin down the exact interleaving that triggers it, so the fix is deliberately defensive rather than targeted at one spec.

### Fix
Restores the locale in a global `teardown`, so no test can leak it regardless of which one set it.

### Testing
`bin/rails test` — six consecutive full-suite runs, no locale-related failures.
