### PR TITLE
fix(images): support ImageMagick 7 (magick) alongside legacy binaries

### DIFF
--- a/app/services/images_service.rb
+++ b/app/services/images_service.rb
@@ -50,7 +50,7 @@ class ImagesService
       require "open3"
 
       # Use ImageMagick identify to get dimensions
-      stdout, stderr, status = Open3.capture3("identify", "-format", "%wx%h", path.to_s)
+      stdout, stderr, status = Open3.capture3(*imagemagick_cmd("identify"), "-format", "%wx%h", path.to_s)
 
       if status.success? && stdout.present?
         match = stdout.strip.match(/(\d+)x(\d+)/)
@@ -338,7 +338,7 @@ class ImagesService
         FileUtils.cp(source_path.to_s, source_file.path)
 
         cmd = [
-          "convert",
+          *imagemagick_cmd("convert"),
           source_file.path,
           "-resize", resize_arg,
           "-quality", "95",
@@ -356,6 +356,11 @@ class ImagesService
 
         file_content = File.binread(output_file.path)
         [ file_content, "image/jpeg", output_name ]
+      rescue Errno::ENOENT => e
+        # No ImageMagick binary at all — degrade to the original file instead of
+        # failing the whole upload (same fallback as a failed resize).
+        Rails.logger.error "ImageMagick not available, skipping resize: #{e.message}"
+        [ source_path.binread, content_type_for(source_path), original_name ]
       ensure
         source_file.unlink
         output_file.unlink
@@ -388,6 +393,27 @@ class ImagesService
         dest_path = images_dir.join(dest_filename)
         FileUtils.cp(temp_path, dest_path)
         { url: "images/#{dest_filename}" }
+      end
+    end
+
+    # ImageMagick 7 replaced the separate `convert` / `identify` binaries with a
+    # single `magick` entrypoint, and several IM7 packages (Homebrew, recent
+    # Debian) ship no `convert` at all — invoking it raises Errno::ENOENT and
+    # breaks image resizing. Resolve the right invocation at call time: prefer
+    # IM7 (`magick`, with `magick identify` for the sub-tool) and fall back to
+    # the IM6 names when only those are installed.
+    def imagemagick_cmd(tool)
+      return [ tool ] unless executable_on_path?("magick")
+
+      tool == "convert" ? [ "magick" ] : [ "magick", tool ]
+    end
+
+    def executable_on_path?(name)
+      ENV.fetch("PATH", "").split(File::PATH_SEPARATOR).any? do |dir|
+        next false if dir.empty?
+
+        candidate = File.join(dir, name)
+        File.file?(candidate) && File.executable?(candidate)
       end
     end
 

--- a/test/services/images_service_test.rb
+++ b/test/services/images_service_test.rb
@@ -286,6 +286,42 @@ class ImagesServiceTest < ActiveSupport::TestCase
     assert_includes %w[image/jpeg image/png], content_type
   end
 
+  test "resize_and_compress falls back to the original file when ImageMagick is missing" do
+    png_data = [
+      0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
+      0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+      0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xDE, 0x00, 0x00, 0x00,
+      0x0C, 0x49, 0x44, 0x41, 0x54, 0x08, 0xD7, 0x63, 0xF8, 0xCF, 0xC0, 0x00,
+      0x00, 0x00, 0x03, 0x00, 0x01, 0x00, 0x05, 0xFE, 0xD4, 0xE7, 0x00, 0x00,
+      0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82
+    ].pack("C*")
+    path = create_test_image("source.png", png_data)
+    Open3.stubs(:capture3).raises(Errno::ENOENT.new("magick"))
+
+    content, content_type, filename = ImagesService.send(:resize_and_compress, path, "source.png", 0.5)
+
+    # Degrades to the original instead of raising and 500ing the upload
+    assert_equal png_data, content
+    assert_equal "image/png", content_type
+    assert_equal "source.png", filename
+  end
+
+  # === imagemagick_cmd (IM6 / IM7 compatibility) ===
+
+  test "imagemagick_cmd uses the magick entrypoint when ImageMagick 7 is installed" do
+    ImagesService.stubs(:executable_on_path?).with("magick").returns(true)
+
+    assert_equal [ "magick" ], ImagesService.send(:imagemagick_cmd, "convert")
+    assert_equal [ "magick", "identify" ], ImagesService.send(:imagemagick_cmd, "identify")
+  end
+
+  test "imagemagick_cmd falls back to the legacy binaries without ImageMagick 7" do
+    ImagesService.stubs(:executable_on_path?).with("magick").returns(false)
+
+    assert_equal [ "convert" ], ImagesService.send(:imagemagick_cmd, "convert")
+    assert_equal [ "identify" ], ImagesService.send(:imagemagick_cmd, "identify")
+  end
+
   # === imagemagick_resize_arg (whitelist) ===
 
   test "imagemagick_resize_arg returns correct percentage for known ratios" do


### PR DESCRIPTION
### Problem
ImageMagick 7 replaced the separate `convert` / `identify` binaries with a single `magick` entrypoint, and several IM7 packages (Homebrew, recent Debian) ship no `convert` at all. On those systems every resize raises `Errno::ENOENT: No such file or directory - convert`, which propagates out of `resize_and_compress` and fails the whole upload, while image dimensions silently come back nil.

This is also why `images_service_test` shows two errors on any machine without IM6 installed.

### Fix
Resolves the invocation at call time — `magick` / `magick identify` when IM7 is present, the IM6 names otherwise — and routes a missing binary to the existing "resize failed" fallback (return the original file) instead of raising.

### Testing
`bin/rails test` — unit tests for both invocation shapes, plus a spec that a missing binary degrades to the original file rather than raising. On a machine with no ImageMagick at all, the suite goes from 2 errors to green.
