### PR TITLE
fix(security): block SSRF in the external-image fetch

### DIFF
--- a/app/services/egress_policy.rb
+++ b/app/services/egress_policy.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "ipaddr"
+require "socket"
+
+# Guard for server-side fetches of user-supplied URLs (SSRF defense).
+#
+# Without it, an endpoint that downloads "an image URL" can be pointed at the
+# cloud metadata service (169.254.169.254), at localhost, or at hosts on the
+# private network the server can reach but the caller cannot.
+#
+# `checked_target` validates the scheme, resolves the host, and rejects the
+# request unless *every* resolved address is a public unicast address. It
+# returns the resolved IP alongside the URI so the caller can pin the
+# connection to the address that was actually validated (via
+# `Net::HTTP#ipaddr=`), which closes the DNS-rebinding window between the
+# check and the connect while keeping the hostname for Host/SNI.
+module EgressPolicy
+  class BlockedError < StandardError; end
+
+  ALLOWED_SCHEMES = %w[http https].freeze
+
+  # Ranges that are never a legitimate fetch target. IPAddr covers loopback,
+  # private and link-local; these are the extra reserved blocks it doesn't.
+  EXTRA_BLOCKED = [
+    IPAddr.new("0.0.0.0/8"),        # "this" network
+    IPAddr.new("100.64.0.0/10"),    # CGNAT
+    IPAddr.new("192.0.0.0/24"),     # IETF protocol assignments
+    IPAddr.new("192.0.2.0/24"),     # TEST-NET-1
+    IPAddr.new("198.18.0.0/15"),    # benchmarking
+    IPAddr.new("198.51.100.0/24"),  # TEST-NET-2
+    IPAddr.new("203.0.113.0/24"),   # TEST-NET-3
+    IPAddr.new("240.0.0.0/4"),      # reserved
+    IPAddr.new("::/128"),           # unspecified
+    IPAddr.new("100::/64")          # discard-only
+  ].freeze
+
+  module_function
+
+  # Returns [URI, resolved_ip_string] for a URL that is safe to fetch.
+  # Raises BlockedError otherwise.
+  def checked_target(url)
+    uri = begin
+      URI.parse(url.to_s)
+    rescue URI::InvalidURIError
+      raise BlockedError, "Invalid URL"
+    end
+
+    unless ALLOWED_SCHEMES.include?(uri.scheme)
+      raise BlockedError, "Only http and https URLs can be fetched"
+    end
+    raise BlockedError, "URL has no host" if uri.host.blank?
+
+    addresses = resolve(uri.host)
+    raise BlockedError, "Could not resolve #{uri.host}" if addresses.empty?
+
+    blocked = addresses.find { |ip| blocked_ip?(ip) }
+    if blocked
+      raise BlockedError, "Refusing to fetch a non-public address (#{blocked})"
+    end
+
+    [ uri, addresses.first.to_s ]
+  end
+
+  def resolve(host)
+    Addrinfo.getaddrinfo(host, nil, nil, :STREAM).filter_map do |info|
+      IPAddr.new(info.ip_address)
+    rescue IPAddr::InvalidAddressError
+      nil
+    end
+  rescue SocketError, ArgumentError
+    []
+  end
+
+  def blocked_ip?(ip)
+    # IPv4-mapped IPv6 (::ffff:127.0.0.1) must be judged on the IPv4 value.
+    ip = ip.native if ip.ipv6? && ip.ipv4_mapped?
+
+    return true if ip.loopback? || ip.private? || ip.link_local?
+    return true if ip.ipv4? && ip.to_i == 0
+    return true if EXTRA_BLOCKED.any? { |range| range.include?(ip) }
+
+    # Multicast: 224.0.0.0/4 and ff00::/8
+    return true if ip.ipv4? && (ip.to_i >> 28) == 0b1110
+    return true if ip.ipv6? && IPAddr.new("ff00::/8").include?(ip)
+
+    false
+  end
+end

--- a/app/services/images_service.rb
+++ b/app/services/images_service.rb
@@ -200,9 +200,17 @@ class ImagesService
       require "securerandom"
       require "tempfile"
 
-      # Download the image
-      uri = URI(url)
+      # Only fetch public http(s) addresses: this URL comes from the client, so
+      # without a check the server can be used to reach cloud metadata
+      # (169.254.169.254), localhost, or private hosts it can see and the caller
+      # cannot. Redirects are not followed (only Net::HTTPSuccess is accepted),
+      # so there is no redirect bypass to re-validate.
+      uri, pinned_ip = EgressPolicy.checked_target(url)
+
       http = Net::HTTP.new(uri.host, uri.port)
+      # Connect to the address we validated (hostname is kept for Host/SNI), so a
+      # DNS record that changes between check and connect can't redirect us.
+      http.ipaddr = pinned_ip
       http.use_ssl = uri.scheme == "https"
       http.open_timeout = 10
       http.read_timeout = 30
@@ -266,6 +274,9 @@ class ImagesService
       end
 
       UploadStorage.s3_url(bucket, region, key)
+    rescue EgressPolicy::BlockedError => e
+      Rails.logger.warn "Refused to fetch external image: #{e.message}"
+      nil
     end
 
     private

--- a/test/services/egress_policy_test.rb
+++ b/test/services/egress_policy_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class EgressPolicyTest < ActiveSupport::TestCase
+  # --- scheme / shape ---
+
+  test "rejects a non-http scheme" do
+    error = assert_raises(EgressPolicy::BlockedError) do
+      EgressPolicy.checked_target("file:///etc/passwd")
+    end
+    assert_includes error.message, "http"
+  end
+
+  test "rejects a URL with no host" do
+    assert_raises(EgressPolicy::BlockedError) { EgressPolicy.checked_target("http://") }
+  end
+
+  test "rejects a host that does not resolve" do
+    EgressPolicy.stubs(:resolve).returns([])
+
+    assert_raises(EgressPolicy::BlockedError) do
+      EgressPolicy.checked_target("https://does-not-exist.invalid/x.png")
+    end
+  end
+
+  # --- address policy (the SSRF vectors) ---
+
+  test "blocks the cloud metadata address" do
+    assert EgressPolicy.blocked_ip?(IPAddr.new("169.254.169.254"))
+  end
+
+  test "blocks loopback, private and link-local addresses" do
+    %w[127.0.0.1 10.0.0.5 172.16.0.1 192.168.1.10 169.254.1.1 ::1 fc00::1 fe80::1].each do |addr|
+      assert EgressPolicy.blocked_ip?(IPAddr.new(addr)), "#{addr} should be blocked"
+    end
+  end
+
+  test "blocks reserved, unspecified and multicast ranges" do
+    %w[0.0.0.0 100.64.0.1 192.0.2.1 198.18.0.1 203.0.113.1 240.0.0.1 224.0.0.1 ff02::1].each do |addr|
+      assert EgressPolicy.blocked_ip?(IPAddr.new(addr)), "#{addr} should be blocked"
+    end
+  end
+
+  test "blocks an IPv4-mapped IPv6 loopback" do
+    # ::ffff:127.0.0.1 must be judged on its IPv4 value, not as a plain v6 address
+    assert EgressPolicy.blocked_ip?(IPAddr.new("::ffff:127.0.0.1"))
+  end
+
+  test "allows a public address" do
+    refute EgressPolicy.blocked_ip?(IPAddr.new("93.184.216.34"))
+    refute EgressPolicy.blocked_ip?(IPAddr.new("2606:2800:220:1:248:1893:25c8:1946"))
+  end
+
+  # --- end to end ---
+
+  test "rejects a host that resolves to a private address" do
+    EgressPolicy.stubs(:resolve).returns([ IPAddr.new("169.254.169.254") ])
+
+    error = assert_raises(EgressPolicy::BlockedError) do
+      EgressPolicy.checked_target("http://metadata.example.com/latest/meta-data/")
+    end
+    assert_includes error.message, "non-public"
+  end
+
+  test "rejects when any resolved address is non-public" do
+    # A host resolving to both a public and a private address must be refused.
+    EgressPolicy.stubs(:resolve).returns([ IPAddr.new("93.184.216.34"), IPAddr.new("127.0.0.1") ])
+
+    assert_raises(EgressPolicy::BlockedError) do
+      EgressPolicy.checked_target("https://split-horizon.example.com/x.png")
+    end
+  end
+
+  test "returns the uri and the resolved ip for a public host" do
+    EgressPolicy.stubs(:resolve).returns([ IPAddr.new("93.184.216.34") ])
+
+    uri, ip = EgressPolicy.checked_target("https://example.com/image.png")
+
+    assert_equal "example.com", uri.host
+    assert_equal "/image.png", uri.path
+    assert_equal "93.184.216.34", ip
+  end
+end

--- a/test/services/images_service_test.rb
+++ b/test/services/images_service_test.rb
@@ -360,6 +360,10 @@ class ImagesServiceS3Test < ActiveSupport::TestCase
     @config_stub.stubs(:get).with("aws_s3_bucket").returns("test-bucket")
     Config.stubs(:new).returns(@config_stub)
 
+    # The external-image fetch resolves the host to enforce the egress policy.
+    # Stub the lookup so the suite stays hermetic (WebMock intercepts HTTP, not DNS).
+    EgressPolicy.stubs(:resolve).returns([ IPAddr.new("93.184.216.34") ])
+
     WebMock.disable_net_connect!(allow_localhost: true)
   end
 
@@ -521,5 +525,18 @@ class ImagesServiceS3Test < ActiveSupport::TestCase
     result = ImagesService.download_and_upload_to_s3("https://example.com/missing.jpg")
 
     assert_nil result
+  end
+
+  test "download_and_upload_to_s3 refuses a host resolving to a non-public address (SSRF)" do
+    EgressPolicy.stubs(:resolve).returns([ IPAddr.new("169.254.169.254") ])
+
+    result = ImagesService.download_and_upload_to_s3("http://169.254.169.254/latest/meta-data/iam/")
+
+    assert_nil result
+    assert_not_requested :get, "http://169.254.169.254/latest/meta-data/iam/"
+  end
+
+  test "download_and_upload_to_s3 refuses a non-http scheme (SSRF)" do
+    assert_nil ImagesService.download_and_upload_to_s3("file:///etc/passwd")
   end
 end


### PR DESCRIPTION
### Problem
`POST /images/upload_external_to_s3` passes the client-supplied URL straight to `Net::HTTP` with no scheme or address check, so the server can be pointed at cloud metadata (169.254.169.254), at localhost, or at private hosts reachable from the server but not from the caller — and the fetched bytes come back to the caller through the resulting (typically public-read) S3 object.

### Fix
Adds an `EgressPolicy` guard: only http/https, the host is resolved, and every resolved address must be public unicast (loopback, RFC1918, link-local, CGNAT, reserved, multicast and the IPv4-mapped equivalents are refused).

The connection is then pinned to the address that was validated, via `Net::HTTP#ipaddr=`, keeping the hostname for Host/SNI — so DNS cannot change between the check and the connect. Redirects were already not followed (only `Net::HTTPSuccess` is accepted), so there is no redirect bypass to re-validate.

### Testing
`bin/rails test` — unit tests for the address policy (metadata address, RFC1918, loopback, link-local, reserved, multicast, IPv4-mapped loopback, split-horizon DNS) plus endpoint tests that a non-public host and a non-http scheme are refused without a request being made. The host lookup is stubbed in the existing S3 specs so the suite stays hermetic — WebMock intercepts HTTP, not DNS.
