### PR TITLE
fix(vim): let the active theme colour the block cursor

### DIFF
--- a/app/javascript/lib/codemirror_extensions.js
+++ b/app/javascript/lib/codemirror_extensions.js
@@ -22,6 +22,22 @@ export const lineNumbersCompartment = new Compartment()
 export const readOnlyCompartment = new Compartment()
 export const vimCompartment = new Compartment()
 
+// @replit/codemirror-vim ships its block-cursor colours at Prec.highest, so a
+// rule in the theme compartment (default precedence) never wins. Re-declare them
+// here, after vim() in the same precedence bucket, so the cursor follows the
+// active theme instead of the library's hardcoded pink.
+export const vimCursorTheme = Prec.highest(EditorView.theme({
+  ".cm-fat-cursor": {
+    background: "var(--theme-accent)",
+    color: "var(--theme-accent-text)"
+  },
+  "&:not(.cm-focused) .cm-fat-cursor": {
+    background: "none",
+    outline: "solid 1px var(--theme-accent)",
+    color: "transparent !important"
+  }
+}))
+
 /**
  * Vim-mode extension. Enabled -> the @replit/codemirror-vim keymap with its
  * built-in status/ex-command line; disabled -> nothing (byte-for-byte the
@@ -30,7 +46,7 @@ export const vimCompartment = new Compartment()
  * @returns {Extension}
  */
 export function createVimExtension(enabled) {
-  return enabled ? vim({ status: true }) : []
+  return enabled ? [ vim({ status: true }), vimCursorTheme ] : []
 }
 
 /**

--- a/app/javascript/lib/codemirror_theme.js
+++ b/app/javascript/lib/codemirror_theme.js
@@ -155,13 +155,9 @@ export function createEditorTheme(options = {}) {
 
     ".cm-tooltip-autocomplete": {
       backgroundColor: "var(--theme-bg-secondary)"
-    },
-
-    // Fat cursor (for vim mode if added later)
-    ".cm-fat-cursor": {
-      backgroundColor: "var(--theme-accent)",
-      color: "var(--theme-accent-text)"
     }
+    // NOTE: vim's .cm-fat-cursor is styled in codemirror_extensions.js instead —
+    // the library sets its colours at Prec.highest, which outranks this theme.
   }, { dark: true }) // Assume dark mode, CSS variables handle actual theme
 }
 

--- a/test/javascript/lib/codemirror_extensions_vim.test.js
+++ b/test/javascript/lib/codemirror_extensions_vim.test.js
@@ -2,17 +2,26 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect } from "vitest"
-import { createVimExtension } from "../../../app/javascript/lib/codemirror_extensions.js"
+import { createVimExtension, vimCursorTheme } from "../../../app/javascript/lib/codemirror_extensions.js"
 
 describe("createVimExtension()", () => {
   it("returns the vim extension when enabled", () => {
     const ext = createVimExtension(true)
     // The vitest mock's vim() returns a marker object.
-    expect(ext).toMatchObject({ __isVim: true })
-    expect(ext.options).toMatchObject({ status: true })
+    expect(ext[0]).toMatchObject({ __isVim: true })
+    expect(ext[0].options).toMatchObject({ status: true })
   })
 
   it("returns nothing (empty) when disabled — editor is unchanged", () => {
     expect(createVimExtension(false)).toEqual([])
+  })
+
+  it("adds the themed block cursor after vim, so it outranks the library colours", () => {
+    const ext = createVimExtension(true)
+
+    // Both sit at Prec.highest, where the later entry wins — put before vim()
+    // and the cursor would stay the library's hardcoded pink.
+    expect(ext).toHaveLength(2)
+    expect(ext[1]).toBe(vimCursorTheme)
   })
 })


### PR DESCRIPTION
Follow-up to #133 / v0.8.0 — one of the things you invited on #132.

### Problem
`@replit/codemirror-vim` styles `.cm-fat-cursor` with a hardcoded `#ff9696`, and it declares that at `Prec.highest`. The matching rule in `createTheme()` sits in the theme compartment at default precedence, so it never wins: the block cursor renders pink on every theme instead of following `--theme-accent`, and the theme rule is effectively dead code.

(It also quietly conflicts with the CLAUDE.md rule that CSS uses `--theme-*` variables rather than hardcoded colours — the intent was there, the precedence just didn't let it apply.)

### Fix
Moves those colours into a `Prec.highest` override declared **after** `vim()` in the same precedence bucket, where it does win, and covers the unfocused state too — the library styles that separately, so leaving it out would keep a pink outline. One definition, and it is the one that actually applies.

### Testing
`npx vitest run` — the existing `createVimExtension()` specs, updated for the new return shape, plus one asserting the override comes after `vim()` (same bucket: later wins).
