### PR TITLE
test(vim): lock the extension-ordering invariant

### DIFF
--- a/test/javascript/lib/codemirror_extensions_vim.test.js
+++ b/test/javascript/lib/codemirror_extensions_vim.test.js
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect } from "vitest"
-import { createVimExtension } from "../../../app/javascript/lib/codemirror_extensions.js"
+import { createVimExtension, createExtensions, vimCompartment } from "../../../app/javascript/lib/codemirror_extensions.js"
 
 describe("createVimExtension()", () => {
   it("returns the vim extension when enabled", () => {
@@ -14,5 +14,18 @@ describe("createVimExtension()", () => {
 
   it("returns nothing (empty) when disabled — editor is unchanged", () => {
     expect(createVimExtension(false)).toEqual([])
+  })
+})
+
+describe("vim extension ordering", () => {
+  it("keeps the vim compartment first in createExtensions()", () => {
+    // Load-bearing, and it fails silently. keymap registers its key handler at
+    // Prec.default, so Prec.highest(keymap.of(...)) does NOT outrank vim —
+    // only position in this array decides who sees the keydown first. Move the
+    // compartment below any keymap.of() and vim's normal mode quietly stops
+    // working (Enter/Backspace/arrows get taken by defaultKeymap).
+    const extensions = createExtensions({})
+
+    expect(extensions[0].compartment).toBe(vimCompartment)
   })
 })


### PR DESCRIPTION
Follow-up to #133 / v0.8.0.

### Why
The comment in `createExtensions()` says the vim compartment must come first, and it is right — but nothing enforces it, and getting it wrong fails *silently* rather than loudly.

`keymap` registers its key handler at `Prec.default` (the facet's `enables` extension is re-rooted there by `flatten()`), so `Prec.highest(keymap.of(...))` does **not** outrank vim — only position in the extension array decides who sees the keydown first. Move the compartment below any `keymap.of()` and vim's normal mode quietly stops working: Enter/Backspace/arrows get taken by `defaultKeymap`, visual-mode Escape gets eaten by `simplifySelection`, and no test fails.

### What
A single assertion that `createExtensions()[0].compartment` is the vim compartment, with the reasoning in a comment so whoever trips it knows why it matters.

Test-only change.
