### PR TITLE
fix(vim): keep FrankMD's own shortcuts working in vim mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,6 +677,8 @@ Standard Vim motions and editing work (`hjkl`, `w/b/e`, `d/c/y/p`, `v`/`V`, `/`,
 
 Notes autosave, so `:w` simply forces an immediate save. There is no Lua/plugin engine — this is modal editing and ex-commands only. See the **Vim Mode** tab in the in-app help (`:help` or F1) for the full reference.
 
+On Windows and Linux, where FrankMD binds `Ctrl`, the shortcuts the app already owns stay with the app rather than Vim: `Ctrl+F`, `Ctrl+N`, `Ctrl+P`, `Ctrl+E`, `Ctrl+B`, `Ctrl+I` and `Ctrl+V`. `Ctrl+D`/`Ctrl+U` still page, and `Ctrl+Q` gives blockwise visual in place of `Ctrl+V`. macOS is unaffected, since app shortcuts use `Cmd` there.
+
 This keeps your typing position steady on the page, which reduces eye movement during longer writing sessions.
 
 ## Hugo Blog Post Support

--- a/app/javascript/controllers/codemirror_controller.js
+++ b/app/javascript/controllers/codemirror_controller.js
@@ -11,7 +11,7 @@ import {
   createLineNumbers,
   LINE_NUMBER_MODES
 } from "lib/codemirror_extensions"
-import { registerVimCommands, observeVimMode } from "lib/vim_mode"
+import { registerVimCommands, observeVimMode, configureVimKeys } from "lib/vim_mode"
 import { createTheme } from "lib/codemirror_theme"
 import {
   createTypewriterExtension,
@@ -508,6 +508,8 @@ export default class extends Controller {
    */
   initVim() {
     if (!this._vimObserver) {
+      // Give the app back the shortcuts it owns before vim can claim them.
+      configureVimKeys()
       registerVimCommands({
         // Ex-commands dispatch a Stimulus event the app controller maps to a
         // FrankMD feature (save, close, finder, sidebar, next/prev, help).

--- a/app/javascript/lib/vim_mode.js
+++ b/app/javascript/lib/vim_mode.js
@@ -13,6 +13,7 @@
 // Both take the library via import; the vitest mock stands in for it in tests.
 
 import { Vim, getCM } from "@replit/codemirror-vim"
+import { isMacOS } from "lib/keyboard_shortcuts"
 
 // Ex-command definitions: [fullName, prefix, logicalCommand].
 // prefix is the shortest accepted abbreviation (vim convention), e.g. :w for :write.
@@ -43,6 +44,43 @@ export function nextNoteIndex(count, currentIndex, direction) {
   if (count <= 0) return -1
   if (currentIndex === -1) return direction > 0 ? 0 : count - 1
   return (currentIndex + direction + count) % count
+}
+
+// Vim claims these Ctrl bindings in normal/visual mode and swallows them
+// (preventDefault + stopPropagation), which on Windows/Linux takes them away
+// from FrankMD and the browser. macOS binds Cmd for app shortcuts, so vim keeps
+// its full keymap there.
+// <C-d>/<C-u> paging is untouched, and <C-q> still gives blockwise visual in
+// place of <C-v> — the standard vim-on-Windows convention.
+export const APP_OWNED_KEYS = [
+  "<C-f>", // find in file      (DEFAULT_SHORTCUTS.findInFile)
+  "<C-n>", // new note          (DEFAULT_SHORTCUTS.newNote)
+  "<C-p>", // file finder       (DEFAULT_SHORTCUTS.fileFinder)
+  "<C-e>", // toggle sidebar    (DEFAULT_SHORTCUTS.toggleSidebar)
+  "<C-b>", // bold              (markdown keymap)
+  "<C-i>", // italic            (markdown keymap)
+  "<C-v>"  // paste             (browser)
+]
+
+let keysConfigured = false
+
+/**
+ * Hand the bindings FrankMD already owns back to the app. Vim.unmap() splices
+ * entries out of the library's shared defaultKeymap, so this is a module-level
+ * mutation: it runs once per page load, not per editor.
+ * @returns {boolean} whether the keys were unmapped
+ */
+export function configureVimKeys(keys = APP_OWNED_KEYS) {
+  if (keysConfigured || isMacOS()) return false
+
+  keys.forEach((key) => Vim.unmap(key))
+  keysConfigured = true
+  return true
+}
+
+// Test-only: reset the one-shot guard.
+export function _resetVimKeys() {
+  keysConfigured = false
 }
 
 let registered = false

--- a/test/javascript/lib/vim_mode.test.js
+++ b/test/javascript/lib/vim_mode.test.js
@@ -2,13 +2,49 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, beforeEach, vi } from "vitest"
-import { registerVimCommands, observeVimMode, EX_COMMANDS, _resetVimCommands } from "../../../app/javascript/lib/vim_mode.js"
+import { registerVimCommands, observeVimMode, EX_COMMANDS, APP_OWNED_KEYS, configureVimKeys, _resetVimCommands, _resetVimKeys } from "../../../app/javascript/lib/vim_mode.js"
+import { isMacOS } from "../../../app/javascript/lib/keyboard_shortcuts.js"
 import { __vimMock } from "@replit/codemirror-vim"
 
 describe("vim_mode", () => {
   beforeEach(() => {
     __vimMock.reset()
     _resetVimCommands()
+    _resetVimKeys()
+  })
+
+  describe("configureVimKeys()", () => {
+    it("hands the app-owned shortcuts back to FrankMD", () => {
+      const applied = configureVimKeys()
+
+      if (isMacOS()) {
+        // App shortcuts use Cmd on macOS, so vim keeps its whole keymap.
+        expect(applied).toBe(false)
+        expect(__vimMock.unmapped).toEqual([])
+      } else {
+        expect(applied).toBe(true)
+        expect(__vimMock.unmapped).toEqual(APP_OWNED_KEYS)
+      }
+    })
+
+    it("only mutates the shared keymap once", () => {
+      configureVimKeys()
+      const afterFirst = __vimMock.unmapped.length
+
+      configureVimKeys()
+
+      expect(__vimMock.unmapped.length).toBe(afterFirst)
+    })
+
+    it("covers the shortcuts the app and the markdown keymap bind", () => {
+      // Ctrl+F/N/P/E are FrankMD shortcuts, Ctrl+B/I are bold/italic, Ctrl+V is
+      // paste. Ctrl+D/U paging and Ctrl+Q blockwise visual stay with vim.
+      expect(APP_OWNED_KEYS).toEqual(
+        expect.arrayContaining([ "<C-f>", "<C-n>", "<C-p>", "<C-e>", "<C-b>", "<C-i>", "<C-v>" ])
+      )
+      expect(APP_OWNED_KEYS).not.toContain("<C-d>")
+      expect(APP_OWNED_KEYS).not.toContain("<C-q>")
+    })
   })
 
   describe("registerVimCommands()", () => {

--- a/test/javascript/mocks/codemirror-vim.js
+++ b/test/javascript/mocks/codemirror-vim.js
@@ -6,10 +6,13 @@
 export const __vimMock = {
   exCommands: [],       // { name, prefix }
   maps: [],             // { lhs, rhs, mode }
+  unmapped: [],         // lhs
+
   modeChangeHandlers: [],
   reset() {
     this.exCommands = []
     this.maps = []
+    this.unmapped = []
     this.modeChangeHandlers = []
   }
 }
@@ -25,6 +28,10 @@ export const Vim = {
   },
   map(lhs, rhs, mode) {
     __vimMock.maps.push({ lhs, rhs, mode })
+  },
+  unmap(lhs) {
+    __vimMock.unmapped.push(lhs)
+    return true
   }
 }
 


### PR DESCRIPTION
Follow-up to #133 / v0.8.0 — one of the things you invited on #132.

### Problem
The README says *"Existing app shortcuts (`Ctrl+S`, `Ctrl+P`, …) keep working alongside it"*, but on Windows/Linux — where FrankMD binds Ctrl — that is not what happens, and `Ctrl+P` is one of the ones that breaks.

In normal and visual mode the vim keymap claims `<C-a> <C-b> <C-d> <C-e> <C-f> <C-i> <C-n> <C-o> <C-p> <C-q> <C-r> <C-t> <C-u> <C-v> <C-w> <C-x> <C-y>` and swallows them (`preventDefault` + `stopPropagation`). Since the vim compartment sits first in the extension array — correctly, so its modal bindings win — it sees the keydown first. So with vim on:

- `Ctrl+P` no longer opens the file finder, `Ctrl+F` no longer opens find, `Ctrl+N` no longer creates a note, `Ctrl+E` no longer toggles the sidebar;
- `Ctrl+B` / `Ctrl+I` no longer bold/italicise (the markdown keymap);
- `Ctrl+V` no longer pastes.

Insert mode was never affected — vim's context filter means these commands don't match while typing.

### Fix
Hands those specific bindings back to the app with a one-time `Vim.unmap()` when vim is enabled, so the README's promise holds. Deliberately narrow:

- `Ctrl+D`/`Ctrl+U` paging is untouched;
- `Ctrl+Q` still gives blockwise visual in place of `Ctrl+V` — the usual vim-on-Windows convention;
- `Ctrl+R` (redo) stays with vim, so it doesn't reload the page;
- macOS short-circuits entirely: app shortcuts use Cmd there, so vim keeps its full keymap.

The list is a judgment call about which side owns which key, so it is deliberately explicit and commented — happy to adjust it if you'd draw the line differently. `Vim.unmap()` mutates the library's shared `defaultKeymap`, so it runs once per page load, guarded the same way `registerVimCommands()` is.

Also documents the Windows/Linux nuance in the README's Vim Mode section.

### Testing
`npx vitest run` — specs for the unmap list, the once-only guard, and the macOS short-circuit. Extends the existing `codemirror-vim` mock with `unmap` (it only had `map`).
