### PR TITLE
Make Docker bind address configurable for VPN-safe local access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,13 @@ IMAGES_PATH=./images
 # Port to expose (default: 7591)
 PORT=7591
 
+# Host address for the published port (default: all interfaces)
+# Use 127.0.0.1 for local-only access, including VPN setups.
+FRANKMD_BIND_ADDRESS=0.0.0.0
+
+# Docker bridge subnet (use this subnet for a narrow VPN allowlist if needed)
+FRANKMD_DOCKER_SUBNET=172.20.0.0/16
+
 # Docker user mapping (prevents bind-mount permission issues)
 UID=1000   # set to: id -u
 GID=1000   # set to: id -g

--- a/README.md
+++ b/README.md
@@ -263,6 +263,15 @@ docker rm -f frankmd
 
 Tip: If you hit permission errors, run the container as your user (`--user "$(id -u):$(id -g)"`) or rebuild the image with matching UID/GID.
 
+For local-only access, bind the published port to loopback instead:
+
+```bash
+docker run -d --name frankmd -p 127.0.0.1:7591:80 \
+  -v ~/notes:/rails/notes \
+  --restart unless-stopped \
+  akitaonrails/frankmd:latest
+```
+
 ### Using Docker Compose
 
 For a more permanent setup, use the `docker-compose.yml` in this repo:
@@ -276,7 +285,7 @@ services:
     container_name: frankmd
     restart: unless-stopped
     ports:
-      - "7591:80"
+      - "${FRANKMD_BIND_ADDRESS:-0.0.0.0}:7591:80"
     volumes:
       - ./notes:/rails/notes
     environment:
@@ -299,6 +308,32 @@ docker compose up -d
 ```
 
 **Note:** The host directory in `NOTES_PATH` must exist and be writable by the UID/GID in `.env`. Avoid `sudo docker`, which creates root-owned bind mounts; if that happens, fix ownership with `chown -R UID:GID <path>`.
+
+By default, Docker publishes FrankMD on all host interfaces. To keep the
+application available only on this machine, set this in `.env` before starting
+or recreating the container:
+
+```env
+FRANKMD_BIND_ADDRESS=127.0.0.1
+```
+
+This is recommended when FrankMD should not be reachable by other devices on
+the local network. Use `0.0.0.0` when LAN access is intentional.
+
+#### Using FrankMD with NordVPN
+
+NordVPN may block traffic between the host and Docker bridge networks while
+LAN Discovery is disabled. You can keep LAN Discovery disabled and allow only
+FrankMD's Docker subnet instead:
+
+```bash
+nordvpn set lan-discovery off
+nordvpn allowlist add subnet 172.20.0.0/16
+```
+
+The default subnet is defined by `FRANKMD_DOCKER_SUBNET`. If you customize it
+in `.env`, allowlist that subnet instead. Combine this with
+`FRANKMD_BIND_ADDRESS=127.0.0.1` to keep FrankMD local-only while using the VPN.
 
 ## Configuration
 
@@ -406,6 +441,9 @@ Environment variables are global defaults. Use them for Docker deployments or wh
 |----------|-------------|---------|
 | `NOTES_PATH` | Directory where notes are stored (must be writable by UID/GID when using Docker) | `./notes` |
 | `IMAGES_PATH` | Directory for local images | (disabled) |
+| `PORT` | Host port for Docker Compose | `7591` |
+| `FRANKMD_BIND_ADDRESS` | Host address for the published Docker port | `0.0.0.0` |
+| `FRANKMD_DOCKER_SUBNET` | Docker bridge subnet used by the Compose network | `172.20.0.0/16` |
 | `IMAGE_UPLOAD_EXTENSIONS` | Comma-separated file extensions accepted by the image drag-and-drop upload | `.jpg,.jpeg,.png,.gif,.webp,.bmp` |
 | `VIDEO_UPLOAD_EXTENSIONS` | Comma-separated file extensions accepted by the video drag-and-drop upload | `.mp4,.webm,.mkv,.mov,.avi,.m4v,.ogv` |
 | `FRANKMD_LOCALE` | Default language (en, pt-BR, pt-PT, es, he, ja, ko) | en |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,8 @@ services:
     # Run as host user for proper volume permissions
     user: "${UID:-1000}:${GID:-1000}"
     ports:
-      - "${PORT:-7591}:80"
+      # Set FRANKMD_BIND_ADDRESS=127.0.0.1 for local-only access.
+      - "${FRANKMD_BIND_ADDRESS:-0.0.0.0}:${PORT:-7591}:80"
     volumes:
       # Notes directory - default to ./notes, override with NOTES_PATH env var
       - ${NOTES_PATH:-./notes}:/rails/notes
@@ -86,3 +87,10 @@ services:
 #     # - Create tunnel at https://one.dash.cloudflare.com/
 #     # - Add public hostname pointing to http://frankmd:80
 #     # - Copy tunnel token to .env as CLOUDFLARE_TUNNEL_TOKEN
+
+networks:
+  default:
+    name: frankmd_default
+    ipam:
+      config:
+        - subnet: ${FRANKMD_DOCKER_SUBNET:-172.20.0.0/16}


### PR DESCRIPTION
## Summary

- Make the Docker Compose host bind address configurable with `FRANKMD_BIND_ADDRESS`.
- Make the Compose Docker bridge subnet configurable with `FRANKMD_DOCKER_SUBNET`.
- Preserve the existing `0.0.0.0` behavior by default while documenting loopback-only access.
- Document local-only `docker run` usage and NordVPN Docker bridge setup.

Fixes #142

## Why

FrankMD was published on all host interfaces by default. That can unintentionally expose unauthenticated notes to other devices on the LAN. NordVPN can also block Docker bridge traffic when LAN Discovery is disabled, creating a confusing situation where the container is healthy but the host cannot reach it.

The new settings provide a clean deployment toggle:

```env
FRANKMD_BIND_ADDRESS=127.0.0.1
FRANKMD_DOCKER_SUBNET=172.20.0.0/16
```

This lets users keep the VPN connected, keep LAN Discovery disabled, allow only the Docker bridge subnet when necessary, and bind FrankMD to loopback so it remains unavailable to other LAN devices.

## Validation

- `bin/rubocop` — passed in an ephemeral Ruby 3.4.8 environment; 76 files inspected.
- `docker compose config` — passed with default and loopback/custom-subnet values.
- `npx vitest run` — 1,398 tests passed; 4 suites fail because the existing package manifest does not declare `@lezer/highlight`.
- `bin/rails test` — 749 tests ran in the ephemeral environment; 5 failures and 9 errors remain in existing permission, asset-precompile, and image-configuration coverage unrelated to these Docker/README changes.

No application code or production dependencies were changed.
