### PR TITLE
feat(docker): make port binding configurable for VPN-safe local access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,13 @@ IMAGES_PATH=./images
 # Port to expose (default: 7591)
 PORT=7591
 
+# Host address for the published port (default: all interfaces)
+# Use 127.0.0.1 for local-only access, including VPN setups.
+FRANKMD_BIND_ADDRESS=0.0.0.0
+
+# Docker bridge subnet (use this subnet for a narrow VPN allowlist if needed)
+FRANKMD_DOCKER_SUBNET=172.20.0.0/16
+
 # Docker user mapping (prevents bind-mount permission issues)
 UID=1000   # set to: id -u
 GID=1000   # set to: id -g

--- a/.env.example
+++ b/.env.example
@@ -25,9 +25,6 @@ PORT=7591
 # Use 127.0.0.1 for local-only access, including VPN setups.
 FRANKMD_BIND_ADDRESS=0.0.0.0
 
-# Docker bridge subnet (use this subnet for a narrow VPN allowlist if needed)
-FRANKMD_DOCKER_SUBNET=172.20.0.0/16
-
 # Docker user mapping (prevents bind-mount permission issues)
 UID=1000   # set to: id -u
 GID=1000   # set to: id -g

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,23 @@ jobs:
       - name: Lint code for consistent style
         run: bin/rubocop -f github
 
+  docker_compose:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Validate default port binding
+        shell: bash
+        run: |
+          set -euo pipefail
+          host_ip=$(docker compose config --format json | jq -r '.services.frankmd.ports[0].host_ip')
+          test "$host_ip" = "0.0.0.0"
+
+      - name: Validate loopback port binding
+        shell: bash
+        run: |
+          set -euo pipefail
+          host_ip=$(FRANKMD_BIND_ADDRESS=127.0.0.1 docker compose config --format json | jq -r '.services.frankmd.ports[0].host_ip')
+          test "$host_ip" = "127.0.0.1"

--- a/README.md
+++ b/README.md
@@ -263,6 +263,15 @@ docker rm -f frankmd
 
 Tip: If you hit permission errors, run the container as your user (`--user "$(id -u):$(id -g)"`) or rebuild the image with matching UID/GID.
 
+For local-only access, bind the published port to loopback instead:
+
+```bash
+docker run -d --name frankmd -p 127.0.0.1:7591:80 \
+  -v ~/notes:/rails/notes \
+  --restart unless-stopped \
+  akitaonrails/frankmd:latest
+```
+
 ### Using Docker Compose
 
 For a more permanent setup, use the `docker-compose.yml` in this repo:
@@ -276,7 +285,7 @@ services:
     container_name: frankmd
     restart: unless-stopped
     ports:
-      - "7591:80"
+      - "${FRANKMD_BIND_ADDRESS:-0.0.0.0}:7591:80"
     volumes:
       - ./notes:/rails/notes
     environment:
@@ -299,6 +308,32 @@ docker compose up -d
 ```
 
 **Note:** The host directory in `NOTES_PATH` must exist and be writable by the UID/GID in `.env`. Avoid `sudo docker`, which creates root-owned bind mounts; if that happens, fix ownership with `chown -R UID:GID <path>`.
+
+By default, Docker publishes FrankMD on all host interfaces. To keep the
+application available only on this machine, set this in `.env` before starting
+or recreating the container:
+
+```env
+FRANKMD_BIND_ADDRESS=127.0.0.1
+```
+
+This is recommended when FrankMD should not be reachable by other devices on
+the local network. Use `0.0.0.0` when LAN access is intentional.
+
+#### Using FrankMD with NordVPN
+
+NordVPN may block traffic between the host and Docker bridge networks while
+LAN Discovery is disabled. You can keep LAN Discovery disabled and allow only
+FrankMD's Docker subnet instead:
+
+```bash
+nordvpn set lan-discovery off
+nordvpn allowlist add subnet 172.20.0.0/16
+```
+
+The default subnet is defined by `FRANKMD_DOCKER_SUBNET`. If you customize it
+in `.env`, allowlist that subnet instead. Combine this with
+`FRANKMD_BIND_ADDRESS=127.0.0.1` to keep FrankMD local-only while using the VPN.
 
 ## Configuration
 
@@ -406,6 +441,9 @@ Environment variables are global defaults. Use them for Docker deployments or wh
 |----------|-------------|---------|
 | `NOTES_PATH` | Directory where notes are stored (must be writable by UID/GID when using Docker) | `./notes` |
 | `IMAGES_PATH` | Directory for local images | (disabled) |
+| `PORT` | Host port for Docker Compose | `7591` |
+| `FRANKMD_BIND_ADDRESS` | Host address for the published Docker port | `0.0.0.0` |
+| `FRANKMD_DOCKER_SUBNET` | Docker bridge subnet used by the Compose network | `172.20.0.0/16` |
 | `IMAGE_UPLOAD_EXTENSIONS` | Comma-separated file extensions accepted by the image drag-and-drop upload | `.jpg,.jpeg,.png,.gif,.webp,.bmp` |
 | `VIDEO_UPLOAD_EXTENSIONS` | Comma-separated file extensions accepted by the video drag-and-drop upload | `.mp4,.webm,.mkv,.mov,.avi,.m4v,.ogv` |
 | `FRANKMD_LOCALE` | Default language (en, pt-BR, pt-PT, es, he, ja, ko) | en |

--- a/README.md
+++ b/README.md
@@ -320,6 +320,13 @@ FRANKMD_BIND_ADDRESS=127.0.0.1
 This is recommended when FrankMD should not be reachable by other devices on
 the local network. Use `0.0.0.0` when LAN access is intentional.
 
+For the strongest localhost-only behavior, use Docker Engine 28.0.0 or newer.
+Docker Engine versions before 28.0.0 may allow hosts on the same local network
+segment to reach ports published to localhost. On older versions, configure a
+host firewall and verify from another device that the host's LAN address cannot
+reach FrankMD; do not treat `127.0.0.1` alone as a complete LAN-isolation
+guarantee.
+
 #### VPN firewall considerations
 
 Some VPN clients block traffic between the host and Docker bridge networks.

--- a/README.md
+++ b/README.md
@@ -320,20 +320,17 @@ FRANKMD_BIND_ADDRESS=127.0.0.1
 This is recommended when FrankMD should not be reachable by other devices on
 the local network. Use `0.0.0.0` when LAN access is intentional.
 
-#### Using FrankMD with NordVPN
+#### VPN firewall considerations
 
-NordVPN may block traffic between the host and Docker bridge networks while
-LAN Discovery is disabled. You can keep LAN Discovery disabled and allow only
-FrankMD's Docker subnet instead:
+Some VPN clients block traffic between the host and Docker bridge networks.
+If FrankMD is healthy but `localhost:7591` is unreachable, keep the VPN
+firewall protections enabled and follow the VPN client's documentation to
+allow only the Docker bridge traffic required for local development. The
+configuration varies by client and operating system; avoid enabling broad LAN
+access unless it is intentional.
 
-```bash
-nordvpn set lan-discovery off
-nordvpn allowlist add subnet 172.20.0.0/16
-```
-
-The default subnet is defined by `FRANKMD_DOCKER_SUBNET`. If you customize it
-in `.env`, allowlist that subnet instead. Combine this with
-`FRANKMD_BIND_ADDRESS=127.0.0.1` to keep FrankMD local-only while using the VPN.
+Regardless of the VPN configuration, use
+`FRANKMD_BIND_ADDRESS=127.0.0.1` when FrankMD should remain local-only.
 
 ## Configuration
 
@@ -443,7 +440,6 @@ Environment variables are global defaults. Use them for Docker deployments or wh
 | `IMAGES_PATH` | Directory for local images | (disabled) |
 | `PORT` | Host port for Docker Compose | `7591` |
 | `FRANKMD_BIND_ADDRESS` | Host address for the published Docker port | `0.0.0.0` |
-| `FRANKMD_DOCKER_SUBNET` | Docker bridge subnet used by the Compose network | `172.20.0.0/16` |
 | `IMAGE_UPLOAD_EXTENSIONS` | Comma-separated file extensions accepted by the image drag-and-drop upload | `.jpg,.jpeg,.png,.gif,.webp,.bmp` |
 | `VIDEO_UPLOAD_EXTENSIONS` | Comma-separated file extensions accepted by the video drag-and-drop upload | `.mp4,.webm,.mkv,.mov,.avi,.m4v,.ogv` |
 | `FRANKMD_LOCALE` | Default language (en, pt-BR, pt-PT, es, he, ja, ko) | en |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,10 +87,3 @@ services:
 #     # - Create tunnel at https://one.dash.cloudflare.com/
 #     # - Add public hostname pointing to http://frankmd:80
 #     # - Copy tunnel token to .env as CLOUDFLARE_TUNNEL_TOKEN
-
-networks:
-  default:
-    name: frankmd_default
-    ipam:
-      config:
-        - subnet: ${FRANKMD_DOCKER_SUBNET:-172.20.0.0/16}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,8 @@ services:
     # Run as host user for proper volume permissions
     user: "${UID:-1000}:${GID:-1000}"
     ports:
-      - "${PORT:-7591}:80"
+      # Set FRANKMD_BIND_ADDRESS=127.0.0.1 for local-only access.
+      - "${FRANKMD_BIND_ADDRESS:-0.0.0.0}:${PORT:-7591}:80"
     volumes:
       # Notes directory - default to ./notes, override with NOTES_PATH env var
       - ${NOTES_PATH:-./notes}:/rails/notes
@@ -86,3 +87,10 @@ services:
 #     # - Create tunnel at https://one.dash.cloudflare.com/
 #     # - Add public hostname pointing to http://frankmd:80
 #     # - Copy tunnel token to .env as CLOUDFLARE_TUNNEL_TOKEN
+
+networks:
+  default:
+    name: frankmd_default
+    ipam:
+      config:
+        - subnet: ${FRANKMD_DOCKER_SUBNET:-172.20.0.0/16}


### PR DESCRIPTION
## Summary

- Make the Docker Compose host bind address configurable with `FRANKMD_BIND_ADDRESS`.
- Preserve the existing `0.0.0.0` behavior by default while documenting loopback-only access.
- Document Docker localhost-publishing limits and generic VPN-firewall considerations.
- Add CI coverage for default and loopback Compose port bindings.

Fixes #142

## Why

FrankMD was published on all host interfaces by default. That can unintentionally expose unauthenticated notes to other devices on the LAN. The new bind-address option lets local developers choose loopback-only access without editing the Compose file.

Use this in `.env` when FrankMD should remain available only on the host:

```env
FRANKMD_BIND_ADDRESS=127.0.0.1
```

Docker Engine versions before 28.0.0 may allow hosts on the same local network segment to reach ports published to localhost. The documentation now calls out this limitation and recommends host-firewall verification for older engines.

Some VPN clients block host-to-Docker traffic while their firewall protections are enabled. The documentation explains this generically and directs users to their VPN client's narrow local-network or Docker-traffic exception mechanism when necessary, without prescribing a provider-specific command.

## Related CI maintenance

The Brakeman latest-version CI failure is addressed separately in [PR #145](https://github.com/akitaonrails/FrankMD/pull/145). This PR remains focused on Docker port binding, documentation, and automated Compose configuration checks.

## Validation

- `docker compose config` — passed with default and loopback bind-address values.
- CI `docker_compose` job — validates default `0.0.0.0` and loopback `127.0.0.1` rendering.
- `npx vitest run` — 1,398 tests passed; 4 suites fail because the existing package manifest does not declare `@lezer/highlight`.
- `bin/rails test` — unavailable in the local environment because Ruby is not installed; previous ephemeral Ruby validation reported only existing unrelated failures.

No application code or production dependencies were changed.
