### PR TITLE
chore(deps): update Brakeman to 8.0.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.25.0)
       msgpack (~> 1.5)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)


### PR DESCRIPTION
## Summary

- Update Brakeman from 8.0.5 to 8.0.6 in `Gemfile.lock`.
- Fix the CI `scan_ruby` check, which fails when Brakeman detects that a newer version is available.

## Validation

- `git diff --check` passes.
- The dependency lockfile resolves Brakeman 8.0.6.

This is intentionally separate from PR #144, which contains the Docker bind-address and VPN documentation changes.